### PR TITLE
Fix facebook login

### DIFF
--- a/src/auth/SocialLoginContent.jsx
+++ b/src/auth/SocialLoginContent.jsx
@@ -88,6 +88,7 @@ const SocialLoginContent = ({ setJWT }) => {
         appId={`${FACEBOOK_APP_ID}`}
         isMobile={false}
         fields="name,email,picture"
+        scope="public_profile,email"
         callback={handleFacebookLogin}
         render={renderProps => (
           <FacebookButton


### PR DESCRIPTION
## Summary

@AyushK1 pointed out today that Facebook login on staging doesn't work.

It turns out that this is because I changed the "default API version" on the `Flow (dev)` app to 5.0 (that is, the latest version), which requires us to request the `email` permission explicitly. 

Since it's probably a good idea to develop against the latest API in any case, this PR fixes that issue as described in [react-facebook-login docs](https://www.npmjs.com/package/react-facebook-login#custom-permission).