### PR TITLE
Fully close circular percentage 

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-spring": "^8.0.27",
     "react-table": "^7.0.0-rc.15",
     "react-toastify": "^5.5.0",
+    "recharts": "^1.8.5",
     "redux": "^4.0.5",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",

--- a/src/components/statistics/CircularPercentage.jsx
+++ b/src/components/statistics/CircularPercentage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { withTheme } from 'styled-components';
+import { PieChart, Pie, Cell } from 'recharts';
 import PropTypes from 'prop-types';
 
 /* Styled Components */
@@ -10,52 +11,6 @@ import {
   GreyText,
 } from './styles/CircularPercentage';
 
-function donut(theme, sidelength, percent, barThickness) {
-  const outerRadius = sidelength / 2;
-  const innerRadius = outerRadius - barThickness;
-
-  // Arc paths cannot form a closed circle
-  if (percent === 100) {
-    return (
-      <g stroke="none">
-        <circle cx="50%" cy="50%" r={outerRadius} fill={theme.primary} />
-        <circle cx="50%" cy="50%" r={innerRadius} fill={theme.white} />
-      </g>
-    );
-  }
-
-  const center = outerRadius;
-  const angle = (percent / 100) * 2 * Math.PI;
-  const cf = Math.cos(angle);
-  const sf = Math.sin(angle);
-  const outerEnd = { x: sf * outerRadius, y: cf * outerRadius };
-  const innerEnd = { x: sf * innerRadius, y: cf * innerRadius };
-  const largeArc = percent >= 50 ? 1 : 0;
-
-  const start = `M ${center} ${center - innerRadius}`;
-  const moveOut = `L ${center} ${center - outerRadius}`;
-  const outerArcStart = `A ${outerRadius} ${outerRadius} 0`;
-  const outerArcEnd = `${center - outerEnd.x} ${center - outerEnd.y}`;
-  const moveIn = `L ${center - innerEnd.x} ${center - innerEnd.y}`;
-  const innerArcStart = `A ${innerRadius} ${innerRadius} 0`;
-  const innerArcEnd = `${center} ${center - innerRadius}`;
-
-  const outerDark = `${outerArcStart} ${largeArc} 0 ${outerArcEnd}`;
-  const outerLight = `${outerArcStart} ${1 - largeArc} 1 ${outerArcEnd}`;
-  const innerDark = `${innerArcStart} ${largeArc} 1 ${innerArcEnd}`;
-  const innerLight = `${innerArcStart} ${1 - largeArc} 0 ${innerArcEnd}`;
-
-  const dark = `${start} ${moveOut} ${outerDark} ${moveIn} ${innerDark}`;
-  const light = `${start} ${moveOut} ${outerLight} ${moveIn} ${innerLight}`;
-
-  return (
-    <g stroke="none">
-      <path d={dark} fill={theme.primary} />
-      <path d={light} fill={theme.light3} />
-    </g>
-  );
-}
-
 //Contained within a square tho
 const CircularPercentage = ({
   theme,
@@ -65,9 +20,22 @@ const CircularPercentage = ({
   label,
 }) => (
   <CircleWrapper>
-    <svg width={height} height={height}>
-      {donut(theme, height, percent, barThickness)}
-    </svg>
+    <PieChart width={height} height={height}>
+      <Pie
+        dataKey="value"
+        data={[{ value: percent }, { value: 100 - percent }]}
+        cx="50%"
+        cy="50%"
+        startAngle={90}
+        endAngle={450}
+        outerRadius={height / 2}
+        innerRadius={height / 2 - barThickness}
+        blendStroke={true}
+      >
+        <Cell fill={theme.primary} />
+        <Cell fill={theme.light3} />
+      </Pie>
+    </PieChart>
     <NumbersInCircle height={height}>
       <LargePercentage>
         {percent !== null ? `${percent}%` : 'N/A'}


### PR DESCRIPTION
I've heard n > 1 IRL complaints about the donut being unclosed when the rating is 100%. This fixes that, also eliminating the recharts dependency (because recharts is bad).

This is a draft because animation is absent. I personally prefer it without the animation, especially since this probably can only really be animated in JS, so it will be slow. If you think animation is important, let's discuss.