### PR TITLE
CourseSchedule: add all section codes

### DIFF
--- a/src/pages/coursePage/CourseSchedule.jsx
+++ b/src/pages/coursePage/CourseSchedule.jsx
@@ -22,11 +22,40 @@ import { termCodeToDate, secsToTime, weekDayLetters } from '../../utils/Misc';
 import { processSectionExams } from '../../utils/FinalExams';
 import CollapsibleContainer from '../../components/display/CollapsibleContainer';
 
-const sectionOrder = {
-  LEC: 0,
-  LAB: 1,
-  TUT: 2,
-};
+// sectionCodes are all the section codes that exist at UW,
+// in the order they should appear in a course schedule.
+const sectionCodes = [
+  // theoretical components
+  'LEC', // lecture: the usual lecture format.
+  'OLN', // online: rare term for online lectures. [ACINTY]
+  'RDG', // reading: independent study under ~1-1 supervision. [CS 690B in 1201]
+  // interactive components
+  'CLN', // clinic: analysis of cases. [OPTOM, PHARM]
+  'DIS', // discussion: group discussions under supervision. [PSCI 231]
+  'ORL', // oral conversation: practicing a foreign language. [FR 192]
+  'SEM', // seminar: less format lecture + project/paper presentations. [SE 101]
+  // practical components
+  'ESS', // essay: just writing essays, apparently... [ENGL 495]
+  'FLD', // field studies: work with primary materials in the field. [EARTH 260]
+  'FLT', // flight training: planes! [AVIA]
+  'LAB', // laboratory: practical tasks, often with special equipment. [ECE 240]
+  'PRA', // practicum: supervised placement in a work setting. [SWREN]
+  'PRJ', // project: the student independently produces a deliverable. [WKRPT]
+  'STU', // studio: coaching based on applied skill execution. [FINE 100]
+  'WRK', // work term: co-op. [COOP]
+  'WSP', // workshop: independent project work under supervision [SVENT]
+  // supplementary components
+  'TUT', // tutorial: usually a TA going over sample problems.
+  // examination components
+  'ENS', // ensemble: evaluation of musical performance. [MUSIC]
+  'TST', // test: usually mid-term exam.
+];
+
+// sectionOrder maps each section code to its index in sectionCodes.
+const sectionOrder = sectionCodes.reduce((map, type, i) => {
+  map[type] = i;
+  return map;
+}, {});
 
 /*
  * We first group the data by time of day range (start and end time) Now, each group should have


### PR DESCRIPTION
Right now our ordering sometimes fails because we don't impose an order on _all_ section codes. The most common one missing is  TST, like in https://uwflow.com/course/cs480, but I figured we might as well add all of them. An additional benefit is that our source is now educational.