### PR TITLE
Make error messages more clear for schedule

### DIFF
--- a/src/components/upload/ScheduleUploadModalContent.tsx
+++ b/src/components/upload/ScheduleUploadModalContent.tsx
@@ -117,7 +117,7 @@ const ScheduleUploadModalContent = ({
       } else {
         const scheduleRes = response as ScheduleParseResponse;
         setUploadError(
-          SCHEDULE_ERRORS.classes_failed(scheduleRes.failed_classes.length),
+          SCHEDULE_ERRORS.classes_failed(scheduleRes.failed_classes),
         );
         onAfterUploadSuccess();
       }

--- a/src/components/upload/styles/DataUploadModals.tsx
+++ b/src/components/upload/styles/DataUploadModals.tsx
@@ -223,8 +223,8 @@ export const ErrorMessage = styled.div`
   width: 100%;
   top: 0;
   left: 0;
-  right: 0
-  z-index: 2;
+  right: 0;
+  z-index: 1;
   color: ${({ theme }) => theme.white};
   background: ${({ theme }) => theme.red};
 `;

--- a/src/constants/Messages.tsx
+++ b/src/constants/Messages.tsx
@@ -40,10 +40,12 @@ export const SCHEDULE_ERRORS: MessageObject = {
     'That looks like an old schedule – try uploading one for the current or next term.',
   default_schedule:
     'We were unable to process your schedule. Get in touch at info@uwflow.com if this persists.',
-  classes_failed: (numClasses: number) =>
-    `We were unable to add ${numClasses} ${
-      numClasses === 1 ? 'class' : 'classes'
-    } to your schedule.
+  classes_failed: (classes: number[]) =>
+    `We were unable to add ${
+      classes.length === 1 ? 'class number' : 'class numbers'
+    } ${classes
+      .join(', ')
+      .replace(/, ((?:.(?!, ))+)$/, ' and $1')} to your schedule.
     Get in touch at info@uwflow.com if this persists.`,
 };
 


### PR DESCRIPTION
Explicitly tell people what classes failed to import so we get less emails (WLU classes, non-graded components, etc.)