### PR TITLE
Pin node version to unbreak build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS builder
+FROM node:16-alpine AS builder
 
 WORKDIR /work
 


### PR DESCRIPTION
While we're not actively updating frontend, we should have the version pinned.