### PR TITLE
Fixed FilterState.hasPrereq Typo

### DIFF
--- a/src/pages/explorePage/ExplorePage.tsx
+++ b/src/pages/explorePage/ExplorePage.tsx
@@ -59,7 +59,7 @@ const ExplorePageContent = ({
   const [nextTerm, setNextTerm] = useState(false);
   const [courseTaught, setCourseTaught] = useState(0);
   const [exploreTab, setExploreTab] = useState(courseTab ? 0 : 1);
-  const [hasPrereqs, setHasPrereqs] = useState(true);
+  const [hasNoPrereqs, setHasNoPrereqs] = useState(true);
 
   const exploreAll = query === '';
 
@@ -96,7 +96,7 @@ const ExplorePageContent = ({
     currentTerm,
     nextTerm,
     courseTaught,
-    hasPrereqs,
+    hasNoPrereqs,
   };
 
   const resetCourseFilters = () => {
@@ -104,7 +104,7 @@ const ExplorePageContent = ({
     setNumCourseRatings(0);
     setCurrentTerm(false);
     setNextTerm(false);
-    setHasPrereqs(true);
+    setHasNoPrereqs(true);
   };
 
   const resetProfFilters = () => {
@@ -148,7 +148,7 @@ const ExplorePageContent = ({
             setCurrentTerm={setCurrentTerm}
             setNextTerm={setNextTerm}
             setCourseTaught={setCourseTaught}
-            setHasPrereqs={setHasPrereqs}
+            setHasPrereqs={setHasNoPrereqs}
             ratingFilters={RATING_FILTERS}
             resetFilters={
               exploreTab === 0 ? resetCourseFilters : resetProfFilters

--- a/src/pages/explorePage/SearchFilter.tsx
+++ b/src/pages/explorePage/SearchFilter.tsx
@@ -145,10 +145,10 @@ const SearchFilter = ({
             <RadioButtonWrapper>
               <RadioButton
                 color={theme.primary}
-                selected={!filterState.hasPrereqs}
+                selected={!filterState.hasNoPrereqs}
                 options={['No prerequisites']}
                 margin="8px 16px 0 0"
-                onClick={() => setHasPrereqs(!filterState.hasPrereqs)}
+                onClick={() => setHasPrereqs(!filterState.hasNoPrereqs)}
                 toggle
               />
             </RadioButtonWrapper>

--- a/src/pages/explorePage/SearchResults.tsx
+++ b/src/pages/explorePage/SearchResults.tsx
@@ -152,8 +152,8 @@ const SearchResults = ({
           (!filterState.nextTerm ||
             (filterState.nextTerm &&
               course.terms.some((term) => Number(term) === nextTermCode))) &&
-          (filterState.hasPrereqs ||
-            (!filterState.hasPrereqs && course.has_prereqs === false)),
+          (filterState.hasNoPrereqs ||
+            (!filterState.hasNoPrereqs && course.has_prereqs === false)),
       )
     : [];
 

--- a/src/types/Common.tsx
+++ b/src/types/Common.tsx
@@ -26,7 +26,7 @@ export type SearchFilterState = {
   currentTerm: boolean;
   nextTerm: boolean;
   courseTaught: number;
-  hasPrereqs: boolean;
+  hasNoPrereqs: boolean;
 };
 
 export type CourseSearchResult = {


### PR DESCRIPTION
Small PR fix so that I can implement #FLOW-17 FE search.  

The /explore page shows all courses with no prerequisites by default. However, the current code sets `hasPrereqs: True` by default, which is a typo. I think it should be `hasNoPrereqs: True` 

It should be `hasNoPrereqs: True` to properly reflect the implemented logic. 

![image](https://github.com/UWFlow/uwflow_frontend/assets/46613983/468a598a-83fc-49ac-bc2b-4928c9e59640)

