### PR TITLE
[FLOW-17] FilterStates can be saved as string URL queries now

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,6 @@ const App = () => {
           component={() => <LoadableProfPage />}
         />
         <Route
-          exact
           path={EXPLORE_PAGE_ROUTE}
           component={() => <LoadableExplorePage />}
         />


### PR DESCRIPTION
> first PR 🤧, please feel free to destroy me if my TS conventions are completely wrong

https://github.com/UWFlow/uwflow_frontend/assets/46613983/b8ff66ff-c9d3-498e-b6f8-9e9326336d8f

1. Added a `useEffect` to the `Explore.tsx` page that updates the URL with an encoded version of `filterState: SearchFilterState`. 

2. Changed the default values for the `filterState: SearchFilterState` to try pulling from the URL before falling back to default values. 

3. I was worried this would negatively affect performance. I did a little profiling, and it seems to be fine, but I would like a confirmation on this. (old 390ms vs new 438ms, not including human-delay) 

![Screenshot 2024-03-15 at 3 12 39 PM](https://github.com/UWFlow/uwflow_frontend/assets/46613983/bc6ea353-adf6-49ad-bfe3-a69476c97508)
![Screenshot 2024-03-15 at 3 10 50 PM](https://github.com/UWFlow/uwflow_frontend/assets/46613983/dff729fe-9085-41aa-b42a-2b24ee5967fb)


