### PR TITLE
modify Sentry Replays to unmask text + media

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -9,11 +9,14 @@ if (process.env.NODE_ENV === 'production') {
       'https://4fc1290ffbf3e98712374e16e8cea4ac@o4504154328465408.ingest.us.sentry.io/4508889530236928',
     integrations: [
       Sentry.reactRouterV5BrowserTracingIntegration({ history }),
-      Sentry.replayIntegration(),
+      Sentry.replayIntegration({
+        maskAllText: false,
+        blockAllMedia: false,
+      }),
     ],
     tracePropagationTargets: ['localhost'],
     // Session Replay
-    replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+    replaysSessionSampleRate: 0.5, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
     replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
 
     // We recommend adjusting this value in production, or using tracesSampler

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -16,7 +16,7 @@ if (process.env.NODE_ENV === 'production') {
     ],
     tracePropagationTargets: ['localhost'],
     // Session Replay
-    replaysSessionSampleRate: 0.5, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+    replaysSessionSampleRate: 0.5, // This sets the sample rate at 50%. You may want to change it to 100% while in development and then sample at a lower rate in production.
     replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
 
     // We recommend adjusting this value in production, or using tracesSampler


### PR DESCRIPTION
Our Sentry replays are kinda useless right now with masking. 