### PR TITLE
Remove Prof's currently teaching courses and requisites information

### DIFF
--- a/src/pages/coursePage/CoursePage.tsx
+++ b/src/pages/coursePage/CoursePage.tsx
@@ -33,7 +33,6 @@ import { createOrderedBuckets, Distribution } from 'utils/Ratings';
 
 import {
   Column1,
-  Column2,
   ColumnWrapper,
   CoursePageWrapper,
   CourseQuestionTextAndToggle,
@@ -42,7 +41,6 @@ import {
   ReviewWrapper,
 } from './styles/CoursePage';
 import CourseInfoHeader from './CourseInfoHeader';
-import CourseRequisites from './CourseRequisites';
 import CourseReviews from './CourseReviews';
 import CourseSchedule from './CourseSchedule';
 
@@ -155,15 +153,6 @@ const CoursePageContent = ({
             profsTeaching={course.profs_teaching}
           />
         </Column1>
-        <Column2>
-          <CourseRequisites
-            courseCode={course.code}
-            prereqs={course.prereqs}
-            antireqs={course.antireqs}
-            coreqs={course.coreqs}
-            postreqs={course.postrequisites}
-          />
-        </Column2>
       </ColumnWrapper>
     </>
   );

--- a/src/pages/coursePage/CoursePage.tsx
+++ b/src/pages/coursePage/CoursePage.tsx
@@ -33,6 +33,7 @@ import { createOrderedBuckets, Distribution } from 'utils/Ratings';
 
 import {
   Column1,
+  Column2,
   ColumnWrapper,
   CoursePageWrapper,
   CourseQuestionTextAndToggle,
@@ -41,6 +42,7 @@ import {
   ReviewWrapper,
 } from './styles/CoursePage';
 import CourseInfoHeader from './CourseInfoHeader';
+import CourseRequisites from './CourseRequisites';
 import CourseReviews from './CourseReviews';
 import CourseSchedule from './CourseSchedule';
 
@@ -153,6 +155,15 @@ const CoursePageContent = ({
             profsTeaching={course.profs_teaching}
           />
         </Column1>
+        <Column2>
+          <CourseRequisites
+            courseCode={course.code}
+            prereqs={course.prereqs}
+            antireqs={course.antireqs}
+            coreqs={course.coreqs}
+            postreqs={course.postrequisites}
+          />
+        </Column2>
       </ColumnWrapper>
     </>
   );

--- a/src/pages/profPage/ProfInfoHeader.tsx
+++ b/src/pages/profPage/ProfInfoHeader.tsx
@@ -16,7 +16,6 @@ import { Distribution } from 'utils/Ratings';
 
 import {
   CourseLink,
-  Description,
   ProfDescriptionSection,
   ProfInfoHeaderWrapper,
   ProfName,
@@ -83,12 +82,6 @@ const ProfInfoHeader = ({ prof, distributions }: ProfInfoHeaderProps) => {
             ]}
           />
         </RatingsSection>
-        <Description ratingBoxWidth={RATING_BOX_WIDTH}>
-          {profCourses.length > 0
-            ? 'Currently teaches'
-            : 'Not currently teaching anything'}
-          {profCourseLinks}
-        </Description>
       </ProfDescriptionSection>
     </ProfInfoHeaderWrapper>
   );

--- a/src/pages/profPage/styles/ProfInfoHeader.tsx
+++ b/src/pages/profPage/styles/ProfInfoHeader.tsx
@@ -76,26 +76,6 @@ export const ProfDescriptionSection = styled.div`
   `}
 `;
 
-export const Description = styled.div<{ ratingBoxWidth: number }>`
-  ${Heading3}
-  position: relative;
-  margin: auto 0;
-  vertical-align: middle;
-  color: ${({ theme }) => theme.dark2};
-
-  ${breakpoint('zero', 'tablet')`
-    margin-bottom: 16px;
-    padding: 0 16px;
-    min-width: 100%;
-  `}
-
-  ${breakpoint('tablet')`
-    margin-top: 48px;
-    max-width: calc(100% - ${({ ratingBoxWidth }: { ratingBoxWidth: number }) =>
-      ratingBoxWidth}px);
-  `}
-`;
-
 export const RatingsSection = styled(FadeIn)<{ ratingBoxHeight: number }>`
   ${breakpoint('zero', 'tablet')`
     width: 100%;


### PR DESCRIPTION
Since UW API is no longer providing what professors are teaching a course, we should remove "currently teaching" on a prof's page. 

Also UW API recently stopped providing requisites description (prerequisites, antirequistes, corequistes etc). We would remove this component for now and add back if this data is back or we figured out another way to fetch it. 


Before: 
<img width="1299" height="374" alt="image" src="https://github.com/user-attachments/assets/c0d9dc9d-424c-4aa1-8c4c-a24764ceb4e9" />
<img width="1318" height="739" alt="image" src="https://github.com/user-attachments/assets/0a0dbfce-be31-41b4-9a10-847a4445d568" />


After: 
<img width="1256" height="399" alt="image" src="https://github.com/user-attachments/assets/03496a70-00a6-4c5e-8f82-d4ee9097a6f8" />
<img width="1244" height="669" alt="image" src="https://github.com/user-attachments/assets/7a90a88a-093b-48a6-a474-0b39857f99e6" />

