### PR TITLE
fix(search-bar) intended focus behaviour

### DIFF
--- a/src/components/navigation/SearchBar.tsx
+++ b/src/components/navigation/SearchBar.tsx
@@ -141,7 +141,7 @@ const SearchBar = ({
   }, [selectedResultIndex, selectedResultRef, inputRef]);
 
   useEffect(() => {
-    if (inputRef.current && !isLanding && navigator.maxTouchPoints) {
+    if (inputRef.current && (!isLanding || navigator.maxTouchPoints)) {
       setOpen(false);
       inputRef.current.blur();
     }

--- a/src/components/navigation/SearchBar.tsx
+++ b/src/components/navigation/SearchBar.tsx
@@ -140,17 +140,12 @@ const SearchBar = ({
     }
   }, [selectedResultIndex, selectedResultRef, inputRef]);
 
-  const hasMounted = useRef(false);
   useEffect(() => {
-    hasMounted.current = true;
-  }, []);
-
-  useEffect(() => {
-    if (inputRef.current && navigator.maxTouchPoints) {
+    if (inputRef.current && !isLanding && navigator.maxTouchPoints) {
       setOpen(false);
       inputRef.current.blur();
     }
-  }, [inputRef]);
+  }, [isLanding, navigator.maxTouchPoints]);
 
   useOnClickOutside(searchBarRef, () => setOpen(false));
 
@@ -375,8 +370,7 @@ const SearchBar = ({
         maxLength={100}
         forwardRef={inputRef}
         onFocus={() => {
-          // Don't show dropdown on initial render
-          if (hasMounted.current) setOpen(true);
+          setOpen(true);
         }}
       />
       {open && renderSearchResults()}


### PR DESCRIPTION
Discovered a bug with the initial dropdown render in #205 
 
mobile|computer
--|--
![mobile_demo](https://github.com/user-attachments/assets/9921666f-7239-4d4e-bb46-012da5ad7fd0)|![computer_demo](https://github.com/user-attachments/assets/8c04be37-d183-4c69-a24b-169e8627c369)


