### PR TITLE
fix: show prod even if no reviews

### DIFF
--- a/src/pages/profPage/ProfInfoHeader.tsx
+++ b/src/pages/profPage/ProfInfoHeader.tsx
@@ -33,7 +33,19 @@ type ProfInfoHeaderProps = {
 };
 
 const ProfInfoHeader = ({ prof, distributions }: ProfInfoHeaderProps) => {
-  const { liked, clear, engaging, filled_count, comment_count } = prof.rating!;
+  const {
+    liked,
+    clear,
+    engaging,
+    filled_count,
+    comment_count,
+  } = prof.rating || {
+    liked: 0,
+    clear: 0,
+    engaging: 0,
+    filled_count: 0,
+    comment_count: 0,
+  };
 
   return (
     <ProfInfoHeaderWrapper>

--- a/src/search/SearchClient.ts
+++ b/src/search/SearchClient.ts
@@ -167,7 +167,7 @@ class SearchClient {
     const courseCodeSet = new Set<string>([]);
     const courseCodeRatings: { [key: string]: number } = {};
 
-    const courses = parsedSearchData.courses.map((course) => {
+    const courses = (parsedSearchData.courses || []).map((course) => {
       const courseLetters = formatCourseCode(course.code).split(' ')[0];
       courseCodeSet.add(courseLetters);
 
@@ -187,7 +187,7 @@ class SearchClient {
       };
     });
 
-    const profs = parsedSearchData.profs.map((prof) => {
+    const profs = (parsedSearchData.profs || []).map((prof) => {
       return {
         ...prof,
         courses:


### PR DESCRIPTION
<img width="1269" height="704" alt="image" src="https://github.com/user-attachments/assets/914f4701-7427-4a06-8201-884ef4671db6" />
If a prof has no reviews and ratings, still show the professors page 