### PR TITLE
fix: restore prereq rendering, looks like they are back

### DIFF
--- a/src/pages/coursePage/CoursePage.tsx
+++ b/src/pages/coursePage/CoursePage.tsx
@@ -158,6 +158,9 @@ const CoursePageContent = ({
         <Column2>
           <CourseRequisites
             courseCode={course.code}
+            prereqs={course.prereqs}
+            antireqs={course.antireqs}
+            coreqs={course.coreqs}
             postreqs={course.postrequisites}
           />
         </Column2>

--- a/src/pages/coursePage/CourseRequisites.tsx
+++ b/src/pages/coursePage/CourseRequisites.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { CourseRequirementsFragment } from 'generated/graphql';
 import { getCoursePageRoute } from 'Routes';
 
-import { formatCourseCode } from 'utils/Misc';
+import { COURSE_CODE_REGEX, formatCourseCode } from 'utils/Misc';
 
 import {
   CourseRequisitesWrapper,
@@ -10,6 +10,8 @@ import {
   GreyText,
   Header,
   LineOfText,
+  ReqInfo,
+  ReqText,
 } from './styles/CourseRequisites';
 
 type CourseRequisitesProps = {
@@ -22,11 +24,79 @@ type CourseRequisitesProps = {
 
 const CourseRequisites = ({
   courseCode,
-
+  prereqs = null,
+  antireqs = null,
+  coreqs = null,
   postreqs = [],
 }: CourseRequisitesProps) => {
+  const parsedRequisites = (requisites: string | null): ReactNode[] => {
+    if (requisites === null) {
+      return [''];
+    }
+
+    let parsedReqs = requisites.replace(/\s{2,}/gi, ' ');
+    parsedReqs = parsedReqs.replace(/\(\s*/gi, '(');
+    parsedReqs = parsedReqs.replace(/\s*\)/gi, ')');
+    parsedReqs = parsedReqs.replace(/\s*\\\s*/gi, '\\');
+    parsedReqs = parsedReqs.replace(/\s*\/\s*/gi, '/');
+
+    const splitText = parsedReqs.split(COURSE_CODE_REGEX);
+    const matches = parsedReqs.match(COURSE_CODE_REGEX);
+
+    if (splitText.length <= 1) {
+      return [parsedReqs];
+    }
+
+    return splitText.reduce(
+      (arr: ReactNode[], element, index) =>
+        matches && matches[index]
+          ? [
+              ...arr,
+              element,
+              <CourseText to={getCoursePageRoute(matches[index])} key={index}>
+                {`${formatCourseCode(matches[index])}`}
+              </CourseText>,
+            ]
+          : [...arr, element],
+      [],
+    );
+  };
+
   return (
     <CourseRequisitesWrapper>
+      <Header>{`${formatCourseCode(courseCode)} prerequisites`}</Header>
+      {prereqs ? (
+        <ReqText>{parsedRequisites(prereqs)}</ReqText>
+      ) : (
+        <LineOfText>
+          <GreyText>No prerequisites</GreyText>
+        </LineOfText>
+      )}
+      <br />
+      <Header>{`${formatCourseCode(courseCode)} corequisites`}</Header>
+      {coreqs ? (
+        <>
+          <ReqInfo>
+            Courses required to be taken concurrently with, or prior to, this
+            course.
+          </ReqInfo>
+          <ReqText>{parsedRequisites(coreqs)}</ReqText>
+        </>
+      ) : (
+        <LineOfText>
+          <GreyText>No corequisites</GreyText>
+        </LineOfText>
+      )}
+      <br />
+      <Header>{`${formatCourseCode(courseCode)} antirequisites`}</Header>
+      {antireqs ? (
+        <ReqText>{parsedRequisites(antireqs)}</ReqText>
+      ) : (
+        <LineOfText>
+          <GreyText>No antirequisites</GreyText>
+        </LineOfText>
+      )}
+      <br />
       <Header>{`${formatCourseCode(courseCode)} leads to`}</Header>
       {postreqs.map(
         (postreq, idx) =>


### PR DESCRIPTION
Restored code for rendering prereq, antireq, coreq info. They were taken down due to missing data from UW API, it looks they are back now. 
<img width="1251" height="482" alt="image" src="https://github.com/user-attachments/assets/4df84c26-40b7-46aa-ac16-16fcef1ce49e" />
