### PR TITLE
Persist explore filters and table sort in URL

### DIFF
--- a/src/pages/explorePage/ExplorePage.tsx
+++ b/src/pages/explorePage/ExplorePage.tsx
@@ -45,6 +45,7 @@ const FILTER_PARAM = {
   nextTerm: 'nextTerm',
   hasRoomAvailable: 'hasRoomAvailable',
   hasOnlineCourse: 'hasOnlineCourse',
+  sortBy: 'sortBy',
 };
 
 // SearchFilterState -> plain object ready for queryString.stringify.
@@ -64,6 +65,7 @@ const filterStateToUrlQuery = (sf: SearchFilterState) => {
     [FILTER_PARAM.nextTerm]: sf.nextTerm || null,
     [FILTER_PARAM.hasRoomAvailable]: sf.hasRoomAvailable || null,
     [FILTER_PARAM.hasOnlineCourse]: sf.hasOnlineSection || null,
+    [FILTER_PARAM.sortBy]: sf.sortBy || null,
   };
 };
 
@@ -90,6 +92,7 @@ const urlQueryToFilterState = (search: string): SearchFilterState => {
     nextTerm: Boolean(pq[FILTER_PARAM.nextTerm]),
     hasRoomAvailable: Boolean(pq[FILTER_PARAM.hasRoomAvailable]),
     hasOnlineSection: Boolean(pq[FILTER_PARAM.hasOnlineCourse]),
+    sortBy: (pq[FILTER_PARAM.sortBy] as string) || '',
   };
 };
 
@@ -174,6 +177,7 @@ const ExplorePageContent = ({
         <Column1>
           <SearchResults
             filterState={filterState}
+            setFilterState={setFilterState}
             data={data}
             error={error}
             exploreTab={exploreTab}

--- a/src/pages/explorePage/ExplorePage.tsx
+++ b/src/pages/explorePage/ExplorePage.tsx
@@ -8,7 +8,7 @@ import {
   ExploreQuery,
   ExploreQueryVariables,
 } from 'generated/graphql';
-import queryString, { ParsedQuery } from 'query-string';
+import queryString from 'query-string';
 
 import { SEO_DESCRIPTIONS } from 'constants/Messages';
 import { MAX_SEARCH_TERMS } from 'constants/Search';
@@ -16,7 +16,7 @@ import {
   EXPLORE_ALL_QUERY,
   EXPLORE_QUERY,
 } from 'graphql/queries/explore/Explore';
-import { Nullable, SearchFilterState } from 'types/Common';
+import { SearchFilterState } from 'types/Common';
 
 import { EXPLORE_PAGE_ROUTE } from '../../Routes';
 
@@ -32,6 +32,66 @@ import SearchFilter from './SearchFilter';
 import SearchResults from './SearchResults';
 
 export const NUM_COURSE_CODE_FILTERS = 5;
+
+// Single source of truth for the URL query param name behind each filter.
+// Serializing and reading back through the SAME names is what keeps filters
+// alive across browser navigation (e.g. /explore -> /course/xyz -> back).
+const FILTER_PARAM = {
+  excludedCourses: 'exclude',
+  minCourseRatings: 'minCourseRatings',
+  minProfRatings: 'minProfRatings',
+  courseTaught: 'courseTaught',
+  currentTerm: 'currentTerm',
+  nextTerm: 'nextTerm',
+  hasRoomAvailable: 'hasRoomAvailable',
+  hasOnlineCourse: 'hasOnlineCourse',
+};
+
+// SearchFilterState -> plain object ready for queryString.stringify.
+// Falsy filters become null so `skipNull` drops them and the URL stays clean.
+const filterStateToUrlQuery = (sf: SearchFilterState) => {
+  const excludedCourses = sf.courseCodes
+    .map((isIncluded, index) => (isIncluded ? -1 : index))
+    .filter((index) => index >= 0);
+
+  return {
+    [FILTER_PARAM.excludedCourses]:
+      excludedCourses.length > 0 ? excludedCourses : null,
+    [FILTER_PARAM.minCourseRatings]: sf.numCourseRatings || null,
+    [FILTER_PARAM.minProfRatings]: sf.numProfRatings || null,
+    [FILTER_PARAM.courseTaught]: sf.courseTaught || null,
+    [FILTER_PARAM.currentTerm]: sf.currentTerm || null,
+    [FILTER_PARAM.nextTerm]: sf.nextTerm || null,
+    [FILTER_PARAM.hasRoomAvailable]: sf.hasRoomAvailable || null,
+    [FILTER_PARAM.hasOnlineCourse]: sf.hasOnlineSection || null,
+  };
+};
+
+// location.search -> SearchFilterState. Inverse of filterStateToUrlQuery.
+const urlQueryToFilterState = (search: string): SearchFilterState => {
+  const pq = queryString.parse(search, { arrayFormat: 'comma' });
+
+  // query-string gives a string for one value and an array for many, so
+  // normalize to an array before reading the excluded course indices.
+  const rawExcluded = pq[FILTER_PARAM.excludedCourses] || [];
+  const courseCodes = Array(NUM_COURSE_CODE_FILTERS).fill(true);
+  ([] as string[]).concat(rawExcluded).forEach((index) => {
+    courseCodes[parseInt(index, 10)] = false;
+  });
+
+  const asNumber = (value: any) => parseInt(value, 10) || 0;
+
+  return {
+    courseCodes,
+    numCourseRatings: asNumber(pq[FILTER_PARAM.minCourseRatings]),
+    numProfRatings: asNumber(pq[FILTER_PARAM.minProfRatings]),
+    courseTaught: asNumber(pq[FILTER_PARAM.courseTaught]),
+    currentTerm: Boolean(pq[FILTER_PARAM.currentTerm]),
+    nextTerm: Boolean(pq[FILTER_PARAM.nextTerm]),
+    hasRoomAvailable: Boolean(pq[FILTER_PARAM.hasRoomAvailable]),
+    hasOnlineSection: Boolean(pq[FILTER_PARAM.hasOnlineCourse]),
+  };
+};
 
 type ExplorePageContentProps = {
   query: string;
@@ -51,31 +111,9 @@ const ExplorePageContent = ({
   loading,
 }: ExplorePageContentProps) => {
   const location = useLocation();
-  const getDefaultFilterState = (pq: ParsedQuery): SearchFilterState => {
-    const courseCodes = Array(NUM_COURSE_CODE_FILTERS).fill(true);
-    if (pq.exclude && pq.exclude instanceof Array) {
-      pq.exclude.forEach((index) => {
-        courseCodes[parseInt(index, 10)] = false;
-      });
-    }
-    return {
-      courseCodes,
-      numCourseRatings: parseInt(pq.minCourseRatings as string, 10) || 0,
-      numProfRatings: parseInt(pq.minProfRatings as string, 10) || 0,
-      currentTerm: Boolean(pq.currentTerm) || false,
-      nextTerm: Boolean(pq.nextTerm) || false,
-      courseTaught: parseInt(pq.courseTaught as string, 10) || 0,
-      hasRoomAvailable: Boolean(pq.hasRoomAvailable) || false,
-      hasOnlineSection: Boolean(pq.hasOnlineCourse) || false,
-    };
-  };
 
   const [filterState, setFilterState] = useState<SearchFilterState>(
-    getDefaultFilterState(
-      queryString.parse(location.search, {
-        arrayFormat: 'comma',
-      }),
-    ),
+    urlQueryToFilterState(location.search),
   );
 
   const [profCourses, setProfCourses] = useState<string[]>(['all courses']);
@@ -108,41 +146,16 @@ const ExplorePageContent = ({
     setProfCourses(['all courses'].concat(parsedProfCourses));
   }, [data, exploreAll]);
 
-  const mapFilterStateToURL = (
-    sf: SearchFilterState,
-  ): Nullable<SearchFilterState> => {
-    return {
-      courseCodes: sf.courseCodes.some((code) => !code) ? sf.courseCodes : [],
-      numCourseRatings: sf.numCourseRatings !== 0 ? sf.numCourseRatings : null,
-      numProfRatings: sf.numProfRatings !== 0 ? sf.numProfRatings : null,
-      currentTerm: sf.currentTerm ? sf.currentTerm : null,
-      nextTerm: sf.nextTerm ? sf.nextTerm : null,
-      courseTaught: sf.courseTaught !== 0 ? sf.courseTaught : null,
-      hasRoomAvailable: sf.hasRoomAvailable ? sf.hasRoomAvailable : null,
-      hasOnlineSection: sf.hasOnlineSection ? sf.hasOnlineSection : null,
-    };
-  };
-
   useEffect(() => {
-    const filterStateURL: Nullable<SearchFilterState> = mapFilterStateToURL(
-      filterState,
-    );
-
-    // Add a comma to the end of the URL if there is only one filter, otherwise query-string can't parse single-element arrays
-    const addComma = filterStateURL.courseCodes?.length === 1 ? ',' : '';
+    const urlQuery = queryString.stringify(filterStateToUrlQuery(filterState), {
+      arrayFormat: 'comma',
+      skipNull: true,
+    });
 
     window.history.replaceState(
       {},
       '',
-      `${EXPLORE_PAGE_ROUTE}?${queryString.stringify(filterStateURL, {
-        arrayFormat: 'comma',
-        skipNull: true,
-        sort: (a, b) => {
-          if (a === 'exclude') return 1; // Always sort 'exclude' to the end
-          if (b === 'exclude') return -1; // Always sort 'exclude' to the end
-          return 0;
-        },
-      })}${addComma}`,
+      urlQuery ? `${EXPLORE_PAGE_ROUTE}?${urlQuery}` : EXPLORE_PAGE_ROUTE,
     );
   }, [filterState]);
 
@@ -175,9 +188,7 @@ const ExplorePageContent = ({
             profCourses={profCourses}
             filterState={filterState}
             setFilterState={setFilterState}
-            resetFilters={() =>
-              setFilterState(getDefaultFilterState(queryString.parse('')))
-            }
+            resetFilters={() => setFilterState(urlQueryToFilterState(''))}
             courseSearch={exploreTab === 0}
           />
         </Column2>

--- a/src/pages/explorePage/ExplorePage.tsx
+++ b/src/pages/explorePage/ExplorePage.tsx
@@ -192,7 +192,12 @@ const ExplorePageContent = ({
             profCourses={profCourses}
             filterState={filterState}
             setFilterState={setFilterState}
-            resetFilters={() => setFilterState(urlQueryToFilterState(''))}
+            resetFilters={() =>
+              setFilterState((prev) => ({
+                ...urlQueryToFilterState(''),
+                sortBy: prev.sortBy,
+              }))
+            }
             courseSearch={exploreTab === 0}
           />
         </Column2>

--- a/src/pages/explorePage/SearchResults.tsx
+++ b/src/pages/explorePage/SearchResults.tsx
@@ -26,6 +26,27 @@ import { RATING_MULTIPLES } from './RatingSlider';
 const currentTermCode = getCurrentTermCode();
 const nextTermCode = getNextTermCode();
 
+// Default sort applied when the URL has no `sortBy` filter; the empty
+// string and this value are treated as equivalent so the default never
+// dirties the URL.
+const DEFAULT_SORT_BY: TableSortBy = { id: 'ratings', desc: false };
+
+// 'name' -> asc, '-name' -> desc, '' -> default sort.
+const parseSortBy = (sortBy: string): TableSortBy[] => {
+  if (!sortBy) return [DEFAULT_SORT_BY];
+  const desc = sortBy.startsWith('-');
+  return [{ id: desc ? sortBy.slice(1) : sortBy, desc }];
+};
+
+// Inverse of parseSortBy. Returns '' for the default sort so the URL
+// stays clean while the table still renders sorted on first load.
+const formatSortBy = (sortBy: TableSortBy[]): string => {
+  if (sortBy.length === 0) return '';
+  const { id, desc } = sortBy[0];
+  if (id === DEFAULT_SORT_BY.id && desc === DEFAULT_SORT_BY.desc) return '';
+  return desc ? `-${id}` : id;
+};
+
 const compareNull = (a: string | number | null, b: string | number | null) => {
   if (a === null && b === null) {
     return 0;
@@ -54,6 +75,7 @@ const stringSort = (a: string | null, b: string | null, desc: boolean) => {
 
 type SearchResultsProps = {
   filterState: SearchFilterState;
+  setFilterState: Dispatch<SetStateAction<SearchFilterState>>;
   error: boolean;
   exploreTab: number;
   setExploreTab: Dispatch<SetStateAction<number>>;
@@ -65,6 +87,7 @@ type SearchResultsProps = {
 
 const SearchResults = ({
   filterState,
+  setFilterState,
   data,
   error,
   exploreTab,
@@ -76,9 +99,9 @@ const SearchResults = ({
   const [numRendered, setNumRendered] = useState(SEARCH_RESULTS_PER_PAGE);
   const [courses, setCourses] = useState<CourseSearchResult[] | null>(null);
   const [profs, setProfs] = useState<ProfSearchResult[] | null>(null);
-  const [tableState, setTableState] = useState<{ sortBy: TableSortBy[] }>({
-    sortBy: [],
-  });
+
+  // Table sort lives in filterState so it can be shared with the URL.
+  const tableSortBy = parseSortBy(filterState.sortBy);
 
   useEffect(() => {
     setNumRendered(SEARCH_RESULTS_PER_PAGE);
@@ -205,8 +228,8 @@ const SearchResults = ({
   const resultsToReturn = useMemo(() => {
     let filtered = courseSearch ? filteredCourses : filteredProfs;
 
-    if (tableState.sortBy.length > 0) {
-      const { id: sortKey, desc } = tableState.sortBy[0];
+    if (tableSortBy.length > 0) {
+      const { id: sortKey, desc } = tableSortBy[0];
 
       filtered = filtered.sort((a: any, b: any) =>
         ['code', 'name'].includes(sortKey)
@@ -218,7 +241,7 @@ const SearchResults = ({
     }
 
     return filtered;
-  }, [courseSearch, filteredCourses, filteredProfs, tableState.sortBy]);
+  }, [courseSearch, filteredCourses, filteredProfs, tableSortBy]);
 
   const tableProps = {
     cellPadding: '16px 0',
@@ -226,8 +249,10 @@ const SearchResults = ({
     sortable: true,
     manualSortBy: true,
     setTableState: (state: any) => {
+      const nextSortBy = formatSortBy((state.sortBy || []) as TableSortBy[]);
+      if (nextSortBy === filterState.sortBy) return;
       setNumRendered(50);
-      setTableState(state);
+      setFilterState((prev) => ({ ...prev, sortBy: nextSortBy }));
     },
   };
 
@@ -253,9 +278,7 @@ const SearchResults = ({
             ),
           )
         }
-        initialState={{
-          sortBy: [{ id: 'ratings', desc: false }],
-        }}
+        initialState={{ sortBy: tableSortBy }}
         doneFetching={doneFetching}
       />
     </SearchResultsContent>

--- a/src/pages/explorePage/SearchResults.tsx
+++ b/src/pages/explorePage/SearchResults.tsx
@@ -144,50 +144,41 @@ const SearchResults = ({
 
   const filteredCourses = courses
     ? courses.filter((course) => {
-        // Filter by course code (e.g., 1XX, 2XX)
+        // The seats/online filters only apply to the selected term; if both
+        // term filters are on, the current term takes priority.
+        const requiredTermCode = filterState.currentTerm
+          ? currentTermCode
+          : filterState.nextTerm
+          ? nextTermCode
+          : null;
+
+        const offeredInRequiredTerm = (terms: number[]) =>
+          requiredTermCode === null || terms.includes(requiredTermCode);
+
+        // Course code matches one of the selected levels (e.g. 1XX, 2XX)
         const matchesCodePattern = courseCodeRegex.test(course.code);
 
-        // Filter by minimum rating requirement
+        // Meets the minimum number of ratings
         const meetsRatingThreshold =
           course.ratings >= RATING_MULTIPLES[filterState.numCourseRatings];
 
-        // Filter by term availability (this term and/or next term)
+        // Offered in the term(s) the user asked for
         const isOfferedInCurrentTerm =
-          !filterState.currentTerm ||
-          course.terms.some((term) => Number(term) === currentTermCode);
+          !filterState.currentTerm || course.terms.includes(currentTermCode);
 
         const isOfferedInNextTerm =
-          !filterState.nextTerm ||
-          course.terms.some((term) => Number(term) === nextTermCode);
+          !filterState.nextTerm || course.terms.includes(nextTermCode);
 
-        // Filter by seat availability
-        let hasSeatsAvailable = true;
-        if (filterState.hasRoomAvailable) {
-          if (filterState.currentTerm) {
-            hasSeatsAvailable = course.terms_with_seats.some(
-              (term) => Number(term) === currentTermCode,
-            );
-          } else if (filterState.nextTerm) {
-            hasSeatsAvailable = course.terms_with_seats.some(
-              (term) => Number(term) === nextTermCode,
-            );
-          }
-        }
+        // Has open seats / an online section in the selected term
+        const hasSeatsAvailable =
+          !filterState.hasRoomAvailable ||
+          offeredInRequiredTerm(course.terms_with_seats);
 
-        let hasOnlineSection = true;
-        if (filterState.hasOnlineSection) {
-          if (filterState.currentTerm) {
-            hasOnlineSection = course.terms_with_online_section.some(
-              (term) => Number(term) === currentTermCode,
-            );
-          } else if (filterState.nextTerm) {
-            hasOnlineSection = course.terms_with_online_section.some(
-              (term) => Number(term) === nextTermCode,
-            );
-          }
-        }
+        const hasOnlineSection =
+          !filterState.hasOnlineSection ||
+          offeredInRequiredTerm(course.terms_with_online_section);
 
-        // All conditions must be true for the course to be included
+        // A course is shown only if it passes every active filter
         return (
           matchesCodePattern &&
           meetsRatingThreshold &&

--- a/src/types/Common.tsx
+++ b/src/types/Common.tsx
@@ -29,6 +29,7 @@ export type SearchFilterState = {
   courseTaught: number;
   hasRoomAvailable: boolean;
   hasOnlineSection: boolean;
+  sortBy: string;
 };
 
 export type Nullable<T> = {


### PR DESCRIPTION
## Summary
https://github.com/user-attachments/assets/4138c735-60b5-428d-8974-55a8eaf26254

## Test plan
- [X] Visit `/explore`, change filters (course code levels, min ratings, term, online section), click into a course, hit browser back — filters restored.
- [X] Click a column header to sort (e.g. `Useful` desc), navigate to a course, hit back — column still sorted with the arrow showing.
- [X] Fresh `/explore` load does not append `?sortBy=ratings` to the URL.