### PR TITLE
fix: prettier formatting in PrivacyPage to unblock CI

### DIFF
--- a/src/pages/privacyPage/PrivacyPage.tsx
+++ b/src/pages/privacyPage/PrivacyPage.tsx
@@ -73,12 +73,12 @@ const PrivacyPage = () => (
         </PageBodyParagraph>
         <PageBodyHeader>Third Party Privacy Policies</PageBodyHeader>
         <PageBodyParagraph>
-          UW Flow&apos;s Privacy Policy does not apply to other software. Thus, we
-          are advising you to consult the respective Privacy Policies of these
-          third parties for more detailed information. This may include their
-          practices and instructions about how to opt-out of certain options.
-          You may find a complete list of these Privacy Policies and their links
-          here:{' '}
+          UW Flow&apos;s Privacy Policy does not apply to other software. Thus,
+          we are advising you to consult the respective Privacy Policies of
+          these third parties for more detailed information. This may include
+          their practices and instructions about how to opt-out of certain
+          options. You may find a complete list of these Privacy Policies and
+          their links here:{' '}
           <a
             href="https://facebook.com/about/privacy"
             target="_blank"


### PR DESCRIPTION
## Summary
- CI (CircleCI build) has been failing since #214 because the rewrapped Third Party Privacy Policies paragraph in `PrivacyPage.tsx` does not match prettier's expected line wrapping
- The Dockerfile runs `yarn lint-nofix` during build, which surfaced 5 `prettier/prettier` errors and aborted the image build
- Rewrap the paragraph to the layout prettier wants; `yarn lint-nofix` now passes locally

## Test plan
- [x] `yarn lint-nofix` passes locally
- [ ] CircleCI `build` job succeeds on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)