### PR TITLE
fix: add missing deps array to refreshAuth useEffect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ const App = () => {
     };
 
     refreshAuth();
-  });
+  }, [isLoggedIn]);
 
   useEffect(() => {
     ReactGA.pageview(window.location.pathname + window.location.search);


### PR DESCRIPTION
## Summary
- Adds `[isLoggedIn]` as the dependency array to the `refreshAuth` `useEffect` in `App.tsx`
- Without it the effect fired on **every render**, hammering `/api/auth/refresh` continuously for logged-in users — visible as excessive network requests in Safari's Web Inspector

## Test plan
- [ ] Log in and verify only one auth refresh request fires on initial load (not on every re-render)
- [ ] Log out and back in — confirm refresh fires again on login

🤖 Generated with [Claude Code](https://claude.com/claude-code)