### PR TITLE
perf(safari): fix font loading and head resource hints

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -3,18 +3,21 @@
   src: local('Anderson Grotesk UltraBold'),
     url(fonts/AndersonGrotesk-Ultrabold.otf) format('opentype');
   font-weight: 800;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Anderson Grotesk';
   src: local('Anderson Grotesk Bold'),
     url(fonts/AndersonGrotesk-Bold.otf) format('opentype');
   font-weight: 600;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Anderson Grotesk';
   src: local('Anderson Grotesk'),
     url(fonts/AndersonGrotesk.otf) format('opentype');
   font-weight: 400;
+  font-display: swap;
 }
 
 html {
@@ -32,9 +35,6 @@ html {
 
   /* Disable auto-enlargement of small text in Safari */
   text-size-adjust: 100%;
-
-  /* Enable kerning and optional ligatures */
-  text-rendering: optimizeLegibility;
 
   box-sizing: border-box;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -3,8 +3,6 @@
   <head>
     <title>UW Flow</title>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-
     <!-- Icons -->
     <link rel="apple-touch-icon" sizes="57x57" href="%PUBLIC_URL%/favicon/apple-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="%PUBLIC_URL%/favicon/apple-icon-60x60.png">
@@ -33,6 +31,7 @@
 
     <!-- Styles -->
     <link rel="stylesheet" href="%PUBLIC_URL%/index.css" />
+    <link rel="preconnect" href="https://rsms.me" crossorigin />
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
 
     <!-- OpenSearch for browser search engine integration -->


### PR DESCRIPTION
## Summary
- **Add `preconnect` for rsms.me** — Safari doesn't auto-preconnect; without this, Inter font CSS load was blocked on a cold DNS→TCP→TLS round-trip before first paint
- **Add `font-display: swap` to all `@font-face` blocks** — Safari's default font block period causes Flash of Invisible Text (FOIT) for Anderson Grotesk; `swap` shows fallback text immediately
- **Remove `text-rendering: optimizeLegibility`** — triggers full ligature/kerning recalculation on all text nodes in Safari; not needed since Inter/Anderson Grotesk handle this natively
- **Remove duplicate `<meta name="viewport">` tag** — two viewport tags existed; kept the more complete `shrink-to-fit=no` variant

## Test plan
- [ ] Verify Inter font loads without blocking first paint (Safari Web Inspector → Waterfall)
- [ ] Verify Anderson Grotesk headings show fallback text immediately rather than being invisible during font load
- [ ] Verify no visual regressions in typography

🤖 Generated with [Claude Code](https://claude.com/claude-code)