### PR TITLE
perf(safari): remove will-change: transform from static elements

### DIFF
--- a/src/pages/aboutPage/styles/AboutPage.tsx
+++ b/src/pages/aboutPage/styles/AboutPage.tsx
@@ -26,7 +26,6 @@ export const PageHeader = styled.div`
   background-color: ${({ theme }) => theme.primaryExtraDark};
   background-size: cover;
   background-repeat: no-repeat;
-  will-change: transform;
   padding-bottom: 32px;
   margin-bottom: 32px;
 

--- a/src/pages/coursePage/styles/CourseInfoHeader.tsx
+++ b/src/pages/coursePage/styles/CourseInfoHeader.tsx
@@ -31,7 +31,6 @@ export const CourseCodeAndNameSection = styled.div`
   background-size: cover;
   background-repeat: no-repeat;
   background-position: left center;
-  will-change: transform;
   position: relative;
   min-height: 160px;
   padding: 16px;

--- a/src/pages/explorePage/styles/ExplorePage.tsx
+++ b/src/pages/explorePage/styles/ExplorePage.tsx
@@ -26,7 +26,6 @@ export const ExploreHeaderWrapper = styled.div`
   background-color: ${({ theme }) => theme.primaryExtraDark};
   background-size: cover;
   background-repeat: no-repeat;
-  will-change: transform;
   flex-direction: column;
   position: relative;
 

--- a/src/pages/landingPage/styles/LandingPage.tsx
+++ b/src/pages/landingPage/styles/LandingPage.tsx
@@ -100,7 +100,6 @@ export const BackgroundImage = styled.div`
   background-size: cover;
   background-position: left center;
   background-repeat: no-repeat;
-  will-change: transform;
 `;
 
 export const AuthContent = styled.div<{ loggedIn?: boolean }>`

--- a/src/pages/privacyPage/styles/PrivacyPage.tsx
+++ b/src/pages/privacyPage/styles/PrivacyPage.tsx
@@ -25,7 +25,6 @@ export const PageHeader = styled.div`
   background-color: ${({ theme }) => theme.primaryExtraDark};
   background-size: cover;
   background-repeat: no-repeat;
-  will-change: transform;
   padding-bottom: 32px;
   margin-bottom: 32px;
 

--- a/src/pages/profPage/styles/ProfInfoHeader.tsx
+++ b/src/pages/profPage/styles/ProfInfoHeader.tsx
@@ -24,7 +24,6 @@ export const ProfNameSection = styled.div`
   background-color: ${({ theme }) => theme.primaryExtraDark};
   background-size: cover;
   background-repeat: no-repeat;
-  will-change: transform;
   position: relative;
   min-height: 120px;
   padding: 16px;

--- a/src/pages/profilePage/styles/ProfileInfoHeader.tsx
+++ b/src/pages/profilePage/styles/ProfileInfoHeader.tsx
@@ -13,7 +13,6 @@ export const ProfileInfoHeaderWrapper = styled.div`
   background-color: ${({ theme }) => theme.primaryExtraDark};
   background-size: cover;
   background-repeat: no-repeat;
-  will-change: transform;
   flex-direction: column;
   position: relative;
 `;
@@ -43,7 +42,6 @@ export const UserPicture = styled.div<{ image: string }>`
   background-image: ${({ image }) => `url(${image})`};
   background-size: 208px;
   background-repeat: no-repeat;
-  will-change: transform;
   ${breakpoint('zero', 'tablet')`
     width: 96px;
     height: 96px;


### PR DESCRIPTION
## Summary
Removes `will-change: transform` from 8 styled-component elements across 7 files. None of these elements apply a `transform` — the hint was set on static SVG-background header/wrapper divs.

`will-change: transform` on static elements tells Safari to promote them to compositing layers unconditionally. On iOS Safari especially, this creates GPU memory pressure for every page that renders one of these headers, contributing to slow first paint and potential jettison by the OS on memory-constrained devices.

Affected files:
- `landingPage/styles/LandingPage.tsx` — `BackgroundImage`
- `aboutPage/styles/AboutPage.tsx` — `PageHeader`
- `explorePage/styles/ExplorePage.tsx` — `ExploreHeaderWrapper`
- `coursePage/styles/CourseInfoHeader.tsx` — `CourseCodeAndNameSection`
- `privacyPage/styles/PrivacyPage.tsx` — `PageHeader`
- `profPage/styles/ProfInfoHeader.tsx` — `ProfNameSection`
- `profilePage/styles/ProfileInfoHeader.tsx` — `ProfileInfoHeaderWrapper`, `UserPicture`

## Test plan
- [ ] Verify all page headers still render correctly with their SVG backgrounds
- [ ] Check Safari Web Inspector → Layers panel to confirm fewer compositing layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)