### PR TITLE
fix(safari): remove px units from stroke-dashoffset SVG animation

### DIFF
--- a/src/components/display/styles/LoadingSpinner.tsx
+++ b/src/components/display/styles/LoadingSpinner.tsx
@@ -13,11 +13,11 @@ const DashAnimation = keyframes`
   }
   50% {
     stroke-dasharray: 89, 200;
-    stroke-dashoffset: -32px;
+    stroke-dashoffset: -32;
   }
   100% {
     stroke-dasharray: 89, 200;
-    stroke-dashoffset: -100px;
+    stroke-dashoffset: -100;
   }
 `;
 


### PR DESCRIPTION
## Summary
- Removes `px` units from `stroke-dashoffset` values in the `DashAnimation` keyframes in `LoadingSpinner.tsx`
- `stroke-dashoffset` is an SVG presentation attribute — it must be unitless. Supplying `px` is technically valid CSS but Safari/WebKit has historically mishandled it in `@keyframes`, causing the spinner animation to render incorrectly or not at all

## Test plan
- [ ] Open a page that shows the loading spinner on Safari and verify it animates smoothly
- [ ] Verify spinner still works correctly on Chrome/Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)