### PR TITLE
perf(safari): remove webpackPrefetch hints from all page chunks

### DIFF
--- a/src/LoadableComponents.tsx
+++ b/src/LoadableComponents.tsx
@@ -1,37 +1,37 @@
 import loadable from '@loadable/component';
 
 export const LoadableLandingPage = loadable(() =>
-  import(/* webpackPrefetch: true */ './pages/landingPage/LandingPage'),
+  import('./pages/landingPage/LandingPage'),
 );
 
 export const LoadableProfilePage = loadable(() =>
-  import(/* webpackPrefetch: true */ './pages/profilePage/ProfilePage'),
+  import('./pages/profilePage/ProfilePage'),
 );
 
 export const LoadableCoursePage = loadable(() =>
-  import(/* webpackPrefetch: true */ './pages/coursePage/CoursePage'),
+  import('./pages/coursePage/CoursePage'),
 );
 
 export const LoadableProfPage = loadable(() =>
-  import(/* webpackPrefetch: true */ './pages/profPage/ProfPage'),
+  import('./pages/profPage/ProfPage'),
 );
 
 export const LoadableExplorePage = loadable(() =>
-  import(/* webpackPrefetch: true */ './pages/explorePage/ExplorePage'),
+  import('./pages/explorePage/ExplorePage'),
 );
 
 export const LoadableNotFoundPage = loadable(() =>
-  import(/* webpackPrefetch: true */ './pages/notFoundPage/NotFoundPage'),
+  import('./pages/notFoundPage/NotFoundPage'),
 );
 
 export const LoadableAboutPage = loadable(() =>
-  import(/* webpackPrefetch: true */ './pages/aboutPage/AboutPage'),
+  import('./pages/aboutPage/AboutPage'),
 );
 
 export const LoadablePrivacyPage = loadable(() =>
-  import(/* webpackPrefetch: true */ './pages/privacyPage/PrivacyPage'),
+  import('./pages/privacyPage/PrivacyPage'),
 );
 
 export const LoadableWelcomePage = loadable(() =>
-  import(/* webpackPrefetch: true */ './pages/welcomePage/WelcomePage'),
+  import('./pages/welcomePage/WelcomePage'),
 );


### PR DESCRIPTION
Note: UWFlow.com (landing page) is really laggy on Safari: this speeds it up

## Summary
- Removes `/* webpackPrefetch: true */` from all 9 loadable page imports in `LoadableComponents.tsx`
- With all pages prefetch-hinted, Safari enqueues 9 chunk requests immediately after first load, congesting the network and competing with resources the current page actually needs
- Code splitting is unaffected — chunks are still loaded on demand when the user navigates

## Test plan
- [ ] Navigate to the landing page and verify no prefetch link headers for page chunks appear in Safari Web Inspector → Network
- [ ] Navigate to a course/prof/explore page and verify it still loads correctly (on-demand chunk fetch works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)