### PR TITLE
perf(safari): defer Google and Facebook SDK injection until after first paint

### DIFF
--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -2,6 +2,7 @@ import React, {
   Dispatch,
   SetStateAction,
   SyntheticEvent,
+  useEffect,
   useState,
 } from 'react';
 import { useDispatch } from 'react-redux';
@@ -47,6 +48,12 @@ const AuthForm = ({
   const dispatch = useDispatch();
 
   const [showLoginForm, setShowLoginForm] = useState(true);
+  const [socialReady, setSocialReady] = useState(false);
+
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => setSocialReady(true));
+    return () => cancelAnimationFrame(raf);
+  }, []);
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
@@ -132,7 +139,7 @@ const AuthForm = ({
             />
           )}
           <OrWrapper>OR</OrWrapper>
-          <SocialLoginContent onAuthSuccess={onAuthSuccess} />
+          {socialReady && <SocialLoginContent onAuthSuccess={onAuthSuccess} />}
           <PrivacyWrapper>
             <GreyText>Read our </GreyText>
             <PrivacyPolicyText to={PRIVACY_PAGE_ROUTE} onClick={closeAuthModal}>


### PR DESCRIPTION
Note: UWFlow.com (landing page) is really laggy on Safari: this speeds it up

## Summary
- `react-google-login` injects `https://apis.google.com/js/api.js` synchronously on mount; `react-facebook-login` does the same for the Facebook SDK
- On Safari, ITP (Intelligent Tracking Prevention) adds extra latency to these cross-origin requests from tracking domains, blocking the landing page from becoming interactive
- Fix: defer mounting `<SocialLoginContent>` by one animation frame (`requestAnimationFrame`) so the browser completes its initial paint before the SDK scripts are injected
- No UX change — the social login buttons appear after the first frame, which is imperceptible

## Test plan
- [ ] Open landing page on Safari → verify Google/Facebook login buttons still appear and work
- [ ] Check Safari Web Inspector → Network: `apis.google.com/js/api.js` should no longer appear in the initial waterfall
- [ ] Verify login via Google and Facebook still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)