### PR TITLE
fix: disable Apollo DevTools in production builds

### DIFF
--- a/src/graphql/apollo.js
+++ b/src/graphql/apollo.js
@@ -86,6 +86,11 @@ export const cache = new InMemoryCache({
 const client = new ApolloClient({
   link,
   cache,
+  // Apollo Client v3 gates the DevTools connection on `globalThis.__DEV__`,
+  // which our Webpack build never defines — so without this it defaults to
+  // enabled and attaches DevTools in production/staging. Tie it to NODE_ENV
+  // instead (DefinePlugin statically replaces this), disabling it in prod.
+  devtools: { enabled: process.env.NODE_ENV !== 'production' },
 });
 
 export default client;


### PR DESCRIPTION
I was testing #245 on staging : https://ec2-3-131-38-71.us-east-2.compute.amazonaws.com/course/health105 and caught a small bug

## Problem

Apollo DevTools attaches on **staging and production**, not just in local dev.

Apollo Client v3 defaults the DevTools connection to `globalThis.__DEV__ !== false` (`@apollo/client/core/ApolloClient.js`):

```js
if (this.devtoolsConfig.enabled === undefined) {
    this.devtoolsConfig.enabled = globalThis.__DEV__ !== false;
}
```

Our Webpack `DefinePlugin` only replaces `process.env.*` (`config/webpack.config.js`), never `__DEV__`. The published v3 code reads `globalThis.__DEV__` — a *member expression*, not a bare `__DEV__` identifier — so DefinePlugin can't substitute it either. At runtime `globalThis.__DEV__` is `undefined`, `false !== undefined` is `true`, and DevTools connects regardless of `NODE_ENV`.

Confirmed in the existing production bundle (`build/static/js/*.chunk.js`): all 105 occurrences are `globalThis.__DEV__`, zero bare `__DEV__`, and nothing assigns it.

## Why this is a regression

The pre-v3 `apollo-client` package defaulted `connectToDevTools` to `process.env.NODE_ENV !== 'production'` — a bare `process.env.NODE_ENV` that DefinePlugin *did* statically replace, so DevTools was correctly off in prod. The v3 migration (#245) switched the gate to `globalThis.__DEV__`, which our build doesn't define.

## Fix

Set `devtools.enabled` explicitly from `process.env.NODE_ENV` (which DefinePlugin replaces, folding to `false` in prod). Passing an explicit value also short-circuits the `globalThis.__DEV__` fallback.

```js
const client = new ApolloClient({
  link,
  cache,
  devtools: { enabled: process.env.NODE_ENV !== 'production' },
});
```

(Preferring `devtools.enabled` over `connectToDevTools` — the latter still works but logs a deprecation warning in 3.14.)

## Testing

- `bun run lint-nofix` passes clean.
- DevTools still available in local dev (`NODE_ENV=development`); disabled in `bun run build` output (`NODE_ENV=production`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)