### PR TITLE
feat: preload page chunks on intent + spinner during chunk fetch

### DIFF
--- a/src/LoadableComponents.tsx
+++ b/src/LoadableComponents.tsx
@@ -1,37 +1,54 @@
+import React from 'react';
 import loadable from '@loadable/component';
+
+import PageLoading from 'components/display/PageLoading';
+
+// Each page is code-split into its own chunk. Over the network (staging/prod) that
+// chunk must download before the page can mount, so without a `fallback` the page
+// area renders blank until it arrives. Show a spinner during that fetch instead.
+const fallback = <PageLoading />;
 
 export const LoadableLandingPage = loadable(
   () => import(/* webpackPrefetch: true */ './pages/landingPage/LandingPage'),
+  { fallback },
 );
 
 export const LoadableProfilePage = loadable(
   () => import(/* webpackPrefetch: true */ './pages/profilePage/ProfilePage'),
+  { fallback },
 );
 
 export const LoadableCoursePage = loadable(
   () => import(/* webpackPrefetch: true */ './pages/coursePage/CoursePage'),
+  { fallback },
 );
 
 export const LoadableProfPage = loadable(
   () => import(/* webpackPrefetch: true */ './pages/profPage/ProfPage'),
+  { fallback },
 );
 
 export const LoadableExplorePage = loadable(
   () => import(/* webpackPrefetch: true */ './pages/explorePage/ExplorePage'),
+  { fallback },
 );
 
 export const LoadableNotFoundPage = loadable(
   () => import(/* webpackPrefetch: true */ './pages/notFoundPage/NotFoundPage'),
+  { fallback },
 );
 
 export const LoadableAboutPage = loadable(
   () => import(/* webpackPrefetch: true */ './pages/aboutPage/AboutPage'),
+  { fallback },
 );
 
 export const LoadablePrivacyPage = loadable(
   () => import(/* webpackPrefetch: true */ './pages/privacyPage/PrivacyPage'),
+  { fallback },
 );
 
 export const LoadableWelcomePage = loadable(
   () => import(/* webpackPrefetch: true */ './pages/welcomePage/WelcomePage'),
+  { fallback },
 );

--- a/src/components/display/PageLoading.tsx
+++ b/src/components/display/PageLoading.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import LoadingSpinner from 'components/display/LoadingSpinner';
+
+const PageLoadingWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 60vh;
+`;
+
+// Full-page fallback shown while a route's lazy JS chunk is being fetched.
+const PageLoading = () => (
+  <PageLoadingWrapper>
+    <LoadingSpinner />
+  </PageLoadingWrapper>
+);
+
+export default PageLoading;

--- a/src/components/navigation/SearchBar.tsx
+++ b/src/components/navigation/SearchBar.tsx
@@ -9,6 +9,11 @@ import React, {
 import { Layers, Search, Square, User, Users } from 'react-feather';
 import Highlighter from 'react-highlight-words';
 import { useHistory, useLocation } from 'react-router-dom';
+import {
+  LoadableCoursePage,
+  LoadableExplorePage,
+  LoadableProfPage,
+} from 'LoadableComponents';
 import queryString from 'query-string';
 import {
   EXPLORE_PAGE_ROUTE,
@@ -28,6 +33,7 @@ import {
 } from 'search/SearchClient';
 import { useSearchContext } from 'search/SearchProvider';
 import { formatCourseCode } from 'utils/Misc';
+import { preloadProps } from 'utils/preload';
 
 import {
   BoldText,
@@ -236,6 +242,7 @@ const SearchBar = ({
       key={code}
       ref={ref}
       isLanding={isLanding}
+      {...preloadProps(LoadableExplorePage)}
     >
       <ResultIcon color={theme.primary} className="primaryicon">
         <Layers />
@@ -262,6 +269,7 @@ const SearchBar = ({
       key={course.code}
       ref={ref}
       isLanding={isLanding}
+      {...preloadProps(LoadableCoursePage)}
     >
       <ResultIcon color={theme.courses}>
         <Square />
@@ -296,6 +304,7 @@ const SearchBar = ({
       key={prof.code}
       ref={ref}
       isLanding={isLanding}
+      {...preloadProps(LoadableProfPage)}
     >
       <ResultIcon color={theme.professors}>
         <User />

--- a/src/pages/explorePage/ExploreTableData.tsx
+++ b/src/pages/explorePage/ExploreTableData.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { LoadableCoursePage, LoadableProfPage } from 'LoadableComponents';
 import { getCoursePageRoute, getProfPageRoute } from 'Routes';
 
 import { ColumnOverride } from 'components/display/Table';
 import { formatCourseCode, processRating } from 'utils/Misc';
+import { preloadProps } from 'utils/preload';
 
 import { CourseCode, ProfName } from './styles/ExplorePage';
 
@@ -13,7 +15,10 @@ export const courseColumns: ColumnOverride[] = [
     align: 'left',
     minWidth: 120,
     Cell: ({ cell }) => (
-      <CourseCode to={getCoursePageRoute(cell.value)}>
+      <CourseCode
+        to={getCoursePageRoute(cell.value)}
+        {...preloadProps(LoadableCoursePage)}
+      >
         {formatCourseCode(cell.value)}
       </CourseCode>
     ),
@@ -61,7 +66,10 @@ export const profColumns: ColumnOverride[] = [
     accessor: 'code_name',
     align: 'left',
     Cell: ({ cell }) => (
-      <ProfName to={getProfPageRoute(cell.value.code)}>
+      <ProfName
+        to={getProfPageRoute(cell.value.code)}
+        {...preloadProps(LoadableProfPage)}
+      >
         {cell.value.name}
       </ProfName>
     ),

--- a/src/utils/preload.ts
+++ b/src/utils/preload.ts
@@ -1,0 +1,14 @@
+// Helpers for warming a route's lazy `@loadable/component` chunk before the user
+// commits to navigating. Over the network (staging/prod) the chunk fetch adds a
+// visible 1-2s gap between click and the page mounting; preloading on hover/focus
+// kicks off that fetch early so the chunk is usually ready by click time.
+
+// Any `@loadable/component` exposes a no-arg-callable `preload()`.
+type Preloadable = { preload: () => void };
+
+// Spread onto a link/button to preload its destination chunk on pointer/keyboard
+// intent, e.g. `<Link {...preloadProps(LoadableCoursePage)} />`.
+export const preloadProps = (loadable: Preloadable) => ({
+  onMouseEnter: () => loadable.preload(),
+  onFocus: () => loadable.preload(),
+});


### PR DESCRIPTION
## Problem

Pages are code-split with `@loadable/component`. Over the network (staging/prod), a route's JS chunk must download **before** the page can mount and its GraphQL queries fire. Until then `@loadable/component` renders nothing, so users see a 1–2s blank gap, then the spinner + network request appear at once. It's invisible locally because the chunk is served instantly.

The recent Apollo v3 migration didn't change the data-fetch timing here (it only swapped an import) — but the larger unified `@apollo/client` made the shared vendor chunk heavier, which is likely why the gap became noticeable.

## Changes

- **`PageLoading` fallback on every lazy page** (`LoadableComponents.tsx` + new `components/display/PageLoading.tsx`): a centered spinner now shows while the chunk downloads instead of a blank page. This also covers deep links / hard refreshes, where there's no prior click to preload from.
- **Preload on intent** (new `utils/preload.ts` + `SearchBar.tsx` + `ExploreTableData.tsx`): a `preloadProps(loadable)` helper returns `{ onMouseEnter, onFocus }` handlers that call `loadable.preload()`. Wired onto the two highest-traffic paths to course/prof pages — the search dropdown results and the explore-table course/prof links — so the chunk is usually cached by click time and the page (and its query) mounts immediately. `onFocus` also warms chunks during keyboard arrow-navigation of the search dropdown.

Chunks already had `webpackPrefetch: true` (idle prefetch); this promotes the fetch to high priority on actual intent and covers cases where idle prefetch hadn't completed.

## Notes
- `preloadProps` is reusable and can be dropped onto the remaining course links (`ProfReviews`, `ProfileCourses`, `ShortlistBox`, `Calendar`) the same way; left out here to keep the PR focused on the high-traffic paths.

## Verification
- ✅ `tsc --noEmit` clean
- ✅ `bun run lint-nofix` (CI gate) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
