### PR TITLE
🚨 EMERGENCY: fix /profile rendering NotFoundPage (user_schedule cache keyFields)

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -11904,40 +11904,40 @@ export type UserScheduleFragment = { __typename?: 'user' } & Pick<
   'id'
 > & {
     schedule: Array<
-      { __typename?: 'user_schedule' } & {
-        section: { __typename?: 'course_section' } & Pick<
-          Course_Section,
-          'id' | 'section_name'
-        > & {
-            exams: Array<
-              { __typename?: 'section_exam' } & Pick<
-                Section_Exam,
-                'date' | 'day' | 'location' | 'start_seconds' | 'end_seconds'
-              >
-            >;
-            meetings: Array<
-              { __typename?: 'section_meeting' } & Pick<
-                Section_Meeting,
-                | 'days'
-                | 'end_date'
-                | 'end_seconds'
-                | 'is_cancelled'
-                | 'location'
-                | 'section_id'
-                | 'start_date'
-                | 'start_seconds'
-              > & {
-                  prof?: Maybe<
-                    { __typename?: 'prof' } & Pick<Prof, 'id' | 'name'>
-                  >;
-                }
-            >;
-            course: { __typename?: 'course' } & Pick<
-              Course,
-              'id' | 'name' | 'code'
-            >;
-          };
-      }
+      { __typename?: 'user_schedule' } & Pick<User_Schedule, 'user_id'> & {
+          section: { __typename?: 'course_section' } & Pick<
+            Course_Section,
+            'id' | 'section_name'
+          > & {
+              exams: Array<
+                { __typename?: 'section_exam' } & Pick<
+                  Section_Exam,
+                  'date' | 'day' | 'location' | 'start_seconds' | 'end_seconds'
+                >
+              >;
+              meetings: Array<
+                { __typename?: 'section_meeting' } & Pick<
+                  Section_Meeting,
+                  | 'days'
+                  | 'end_date'
+                  | 'end_seconds'
+                  | 'is_cancelled'
+                  | 'location'
+                  | 'section_id'
+                  | 'start_date'
+                  | 'start_seconds'
+                > & {
+                    prof?: Maybe<
+                      { __typename?: 'prof' } & Pick<Prof, 'id' | 'name'>
+                    >;
+                  }
+              >;
+              course: { __typename?: 'course' } & Pick<
+                Course,
+                'id' | 'name' | 'code'
+              >;
+            };
+        }
     >;
   };
 
@@ -12710,6 +12710,7 @@ export const UserScheduleFragmentDoc = gql`
   fragment UserSchedule on user {
     id
     schedule {
+      user_id
       section {
         id
         exams {

--- a/src/graphql/fragments/UserFragment.tsx
+++ b/src/graphql/fragments/UserFragment.tsx
@@ -29,6 +29,7 @@ const UserFragment = {
     fragment UserSchedule on user {
       id
       schedule {
+        user_id
         section {
           id
           exams {


### PR DESCRIPTION
## 🚨 Emergency fix

`/profile` rendered the NotFoundPage ("page does not exist") for **every logged-in user with a schedule**.

## Root cause

The Apollo v3 migration (#245) added per-type cache `keyFields` in `apollo.js`:

```js
user_schedule: {
  keyFields: ['user_id', 'section', ['id']],
}
```

But the `UserSchedule` fragment only selected `schedule { section { ... } }` — it never selected `user_id`. Apollo's `InMemoryCache` requires every field named in `keyFields` to be present in the selection set, so normalizing the `getUser` response threw:

```
Missing field 'user_id' while extracting keyFields from
{ section: {...}, __typename: 'user_schedule' }
```

That surfaced as an `ApolloError` on the query, and `ProfilePage` falls through to `<NotFoundPage />` whenever `error || !data`.

## Fix

Add `user_id` to the `schedule` selection in the `UserSchedule` fragment so cache normalization succeeds. Generated types synced to match.

> Note: `bun run generate` currently fails on a **pre-existing** duplicate-fragment-name issue (the codegen `documents` glob includes the generated file itself), so the generated types were synced by hand. Worth fixing separately.

## Testing

- `bun run lint-nofix` — clean
- Confirmed the failing normalization came from the `user_schedule` keyFields path; `user_id` is a valid scalar on the `user_schedule` type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)