### PR TITLE
test: add route reachability tests for the App route Switch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,7 @@
         "@graphql-codegen/typescript": "^1.17.6",
         "@graphql-codegen/typescript-operations": "^1.17.6",
         "@graphql-codegen/typescript-react-apollo": "^1.17.6",
+        "@testing-library/react": "^14.3.1",
         "@types/jest": "^25.2.1",
         "@types/loadable__component": "^5.10.0",
         "@types/lodash": "^4.14.150",
@@ -634,9 +635,15 @@
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@1.1.2", "", { "dependencies": { "defer-to-connect": "^1.0.1" } }, "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA=="],
 
+    "@testing-library/dom": ["@testing-library/dom@9.3.4", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.1.3", "chalk": "^4.1.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "pretty-format": "^27.0.2" } }, "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ=="],
+
+    "@testing-library/react": ["@testing-library/react@14.3.1", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@testing-library/dom": "^9.0.0", "@types/react-dom": "^18.0.0" }, "peerDependencies": { "react": "^18.0.0", "react-dom": "^18.0.0" } }, "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ=="],
+
     "@tippyjs/react": ["@tippyjs/react@4.2.6", "", { "dependencies": { "tippy.js": "^6.3.1" } }, "sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw=="],
 
     "@tootallnate/once": ["@tootallnate/once@1.1.2", "", {}, "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.1.7", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw=="],
 
@@ -1376,6 +1383,8 @@
 
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
     "dom-converter": ["dom-converter@0.2.0", "", { "dependencies": { "utila": "~0.4" } }, "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA=="],
 
     "dom-helpers": ["dom-helpers@5.1.4", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^2.6.7" } }, "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A=="],
@@ -1445,6 +1454,8 @@
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-get-iterator": ["es-get-iterator@1.1.3", "", { "dependencies": { "call-bind": "^1.0.2", "get-intrinsic": "^1.1.3", "has-symbols": "^1.0.3", "is-arguments": "^1.1.1", "is-map": "^2.0.2", "is-set": "^2.0.2", "is-string": "^1.0.7", "isarray": "^2.0.5", "stop-iteration-iterator": "^1.0.0" } }, "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw=="],
 
     "es-iterator-helpers": ["es-iterator-helpers@1.3.2", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.2", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.1.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.3.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.5", "math-intrinsics": "^1.1.0" } }, "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw=="],
 
@@ -3796,6 +3807,12 @@
 
     "@svgr/webpack/@babel/core": ["@babel/core@7.9.6", "", { "dependencies": { "@babel/code-frame": "^7.8.3", "@babel/generator": "^7.9.6", "@babel/helper-module-transforms": "^7.9.0", "@babel/helpers": "^7.9.6", "@babel/parser": "^7.9.6", "@babel/template": "^7.8.6", "@babel/traverse": "^7.9.6", "@babel/types": "^7.9.6", "convert-source-map": "^1.7.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.1", "json5": "^2.1.2", "lodash": "^4.17.13", "resolve": "^1.3.2", "semver": "^5.4.1", "source-map": "^0.5.0" } }, "sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg=="],
 
+    "@testing-library/dom/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@testing-library/dom/aria-query": ["aria-query@5.1.3", "", { "dependencies": { "deep-equal": "^2.0.5" } }, "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ=="],
+
+    "@testing-library/dom/pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "@types/babel__core/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "@types/babel__generator/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
@@ -4075,6 +4092,8 @@
     "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "enhanced-resolve/memory-fs": ["memory-fs@0.5.0", "", { "dependencies": { "errno": "^0.1.3", "readable-stream": "^2.0.1" } }, "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA=="],
+
+    "es-get-iterator/is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
 
     "escodegen/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
@@ -5170,6 +5189,12 @@
 
     "@svgr/webpack/@babel/core/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
+    "@testing-library/dom/aria-query/deep-equal": ["deep-equal@2.2.3", "", { "dependencies": { "array-buffer-byte-length": "^1.0.0", "call-bind": "^1.0.5", "es-get-iterator": "^1.1.3", "get-intrinsic": "^1.2.2", "is-arguments": "^1.1.1", "is-array-buffer": "^3.0.2", "is-date-object": "^1.0.5", "is-regex": "^1.1.4", "is-shared-array-buffer": "^1.0.2", "isarray": "^2.0.5", "object-is": "^1.1.5", "object-keys": "^1.1.1", "object.assign": "^4.1.4", "regexp.prototype.flags": "^1.5.1", "side-channel": "^1.0.4", "which-boxed-primitive": "^1.0.2", "which-collection": "^1.0.1", "which-typed-array": "^1.1.13" } }, "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA=="],
+
+    "@testing-library/dom/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "@types/react-redux/redux/symbol-observable": ["symbol-observable@1.2.0", "", {}, "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="],
 
     "@typescript-eslint/typescript-estree/globby/array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
@@ -6203,6 +6228,10 @@
     "@svgr/core/cosmiconfig/import-fresh/resolve-from": ["resolve-from@3.0.0", "", {}, "sha1-six699nWiBvItuZTM17rywoYh0g="],
 
     "@svgr/plugin-svgo/cosmiconfig/import-fresh/resolve-from": ["resolve-from@3.0.0", "", {}, "sha1-six699nWiBvItuZTM17rywoYh0g="],
+
+    "@testing-library/dom/aria-query/deep-equal/is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
+
+    "@testing-library/dom/aria-query/deep-equal/object-is": ["object-is@1.1.6", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1" } }, "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q=="],
 
     "babel-code-frame/chalk/strip-ansi/ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
 

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@graphql-codegen/typescript": "^1.17.6",
     "@graphql-codegen/typescript-operations": "^1.17.6",
     "@graphql-codegen/typescript-react-apollo": "^1.17.6",
+    "@testing-library/react": "^14.3.1",
     "@types/jest": "^25.2.1",
     "@types/loadable__component": "^5.10.0",
     "@types/lodash": "^4.14.150",

--- a/src/__tests__/routes.test.tsx
+++ b/src/__tests__/routes.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import App from 'App';
+import { createStore } from 'redux';
+import {
+  ABOUT_PAGE_ROUTE,
+  EXPLORE_PAGE_ROUTE,
+  getCoursePageRoute,
+  getProfPageRoute,
+  LANDING_PAGE_ROUTE,
+  PRIVACY_PAGE_ROUTE,
+  PROFILE_PAGE_ROUTE,
+  WELCOME_PAGE_ROUTE,
+} from 'Routes';
+
+/**
+ * Route reachability: render the *real* <App> Switch at each declared route
+ * URL and assert the intended page is reached (not the NotFound catch-all).
+ *
+ * The page components are loaded lazily through `LoadableComponents`; we mock
+ * that module so each page is a synchronous stub tagged with a test id. This
+ * keeps the test focused on the routing table (the thing under test) without
+ * pulling in Apollo/Redux data fetching from the real pages. Every other leaf
+ * that <App> mounts (navbar, footer, banners, analytics, modals, sentry) is
+ * mocked to a no-op so the only thing that decides what renders is the Switch.
+ *
+ * `jest.mock` calls are hoisted above the imports above, so the mocks are in
+ * place by the time `App` (and its dependency graph) is loaded.
+ */
+
+// Each lazy page becomes a synchronous stub carrying a unique test id, so the
+// assertion is simply "which page stub is in the document for this URL".
+jest.mock('LoadableComponents', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const ReactLib = require('react');
+  const stub = (testId: string) => () =>
+    ReactLib.createElement('div', { 'data-testid': testId });
+  return {
+    LoadableLandingPage: stub('page-landing'),
+    LoadableProfilePage: stub('page-profile'),
+    LoadableCoursePage: stub('page-course'),
+    LoadableProfPage: stub('page-prof'),
+    LoadableExplorePage: stub('page-explore'),
+    LoadableNotFoundPage: stub('page-notfound'),
+    LoadableAboutPage: stub('page-about'),
+    LoadablePrivacyPage: stub('page-privacy'),
+    LoadableWelcomePage: stub('page-welcome'),
+  };
+});
+
+// SentryRoute is just `withSentryRouting(Route)` in production; for routing
+// purposes a plain react-router Route behaves identically.
+jest.mock('../sentry', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { Route } = require('react-router-dom');
+  return { SentryRoute: Route };
+});
+
+// Chrome that mounts on every route but is irrelevant to reachability.
+jest.mock('components/navigation/Navbar', () => () => null);
+jest.mock('components/navigation/Footer', () => () => null);
+jest.mock('components/banner/AnnouncementBanner', () => () => null);
+jest.mock('components/modal/ModalMount', () => () => null);
+
+// Side-effecting libs that App touches at module load / render time.
+jest.mock('react-modal', () => ({ setAppElement: jest.fn() }));
+jest.mock('react-ga', () => ({
+  initialize: jest.fn(),
+  pageview: jest.fn(),
+  set: jest.fn(),
+}));
+jest.mock('react-helmet', () => ({ Helmet: () => null }));
+jest.mock('react-toastify', () => ({
+  ToastContainer: () => null,
+  Bounce: {},
+}));
+
+// <App> only reads `state.auth.loggedIn`; a frozen logged-out store is enough.
+const renderAt = (path: string) => {
+  const store = createStore(() => ({ auth: { loggedIn: false } }));
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[path]}>
+        <App />
+      </MemoryRouter>
+    </Provider>,
+  );
+};
+
+describe('App route reachability', () => {
+  const reachable: Array<{ name: string; path: string; testId: string }> = [
+    { name: 'landing', path: LANDING_PAGE_ROUTE, testId: 'page-landing' },
+    { name: 'profile', path: PROFILE_PAGE_ROUTE, testId: 'page-profile' },
+    {
+      name: 'course',
+      path: getCoursePageRoute('CS135'),
+      testId: 'page-course',
+    },
+    {
+      name: 'professor',
+      path: getProfPageRoute('jane_doe'),
+      testId: 'page-prof',
+    },
+    { name: 'explore', path: EXPLORE_PAGE_ROUTE, testId: 'page-explore' },
+    { name: 'about', path: ABOUT_PAGE_ROUTE, testId: 'page-about' },
+    { name: 'privacy', path: PRIVACY_PAGE_ROUTE, testId: 'page-privacy' },
+    { name: 'welcome', path: WELCOME_PAGE_ROUTE, testId: 'page-welcome' },
+  ];
+
+  // Use a forEach (not it.each `$name`) so titles read clearly on Jest 24,
+  // which predates named template interpolation.
+  reachable.forEach(({ name, path, testId }) => {
+    it(`reaches the ${name} page at "${path}"`, () => {
+      renderAt(path);
+      expect(screen.getByTestId(testId)).toBeTruthy();
+      expect(screen.queryByTestId('page-notfound')).toBeNull();
+    });
+  });
+
+  it('redirects the short /prof/:profCode route to the professor page', () => {
+    renderAt('/prof/jane_doe');
+    expect(screen.getByTestId('page-prof')).toBeTruthy();
+    expect(screen.queryByTestId('page-notfound')).toBeNull();
+  });
+
+  it('treats explore as a prefix route (sub-paths still reach explore)', () => {
+    renderAt('/explore/courses');
+    expect(screen.getByTestId('page-explore')).toBeTruthy();
+  });
+
+  it('renders NotFound for an unknown route', () => {
+    renderAt('/this/route/does/not/exist');
+    expect(screen.getByTestId('page-notfound')).toBeTruthy();
+  });
+
+  it('enforces exact matching (a sub-path of an exact route is NotFound)', () => {
+    renderAt('/profile/settings');
+    expect(screen.getByTestId('page-notfound')).toBeTruthy();
+    expect(screen.queryByTestId('page-profile')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds an automated test suite (`src/__tests__/routes.test.tsx`) that verifies **every route declared in `App.tsx` is reachable** — i.e. each route URL resolves to its intended page rather than silently falling through to the `NotFound` catch-all.

## Why

The most recent `main` commit was an emergency fix for `/profile` rendering `NotFoundPage`. That's exactly the class of regression these tests guard against: a route that compiles fine but no longer resolves to the right page. There was previously no test covering the routing table.

## How

The test renders the **real `<App>` `<Switch>`** inside a `MemoryRouter` at each route URL and asserts the correct page is reached. To keep the test focused on routing (and free of Apollo/Redux data fetching):

- Lazy pages are mocked via `LoadableComponents` to synchronous stubs, each tagged with a unique `data-testid`.
- Surrounding chrome (navbar, footer, banner, modal mount, analytics, sentry) is mocked to no-ops, so the only thing deciding what renders is the Switch.
- `jest.mock` calls are hoisted above imports, so mocks are in place before `App` loads.

Each positive case also asserts `NotFound` is **absent**, and dedicated tests prove the catch-all *does* render `NotFound` — so a removed/broken route fails the suite instead of passing silently.

### Coverage (12 tests)

- All 8 page routes reach their page: `/`, `/profile`, `/course/:courseCode`, `/professor/:profCode`, `/explore`, `/about`, `/privacy`, `/welcome`
- The short `/prof/:profCode` route **redirects** to the professor page
- `/explore/...` works as a **prefix** (non-exact) route
- Unknown routes fall through to **NotFound**
- Exact matching is enforced (`/profile/settings` → NotFound, not Profile)

## Dependency

Adds `@testing-library/react@^14.3.1` as a **devDependency** (v14 bundles its DOM utilities — no extra peer deps; compatible with the pinned React 18 / Jest 24). Updated via `bun add`; `bun.lock` is the source of truth (no `yarn.lock` reintroduced).

## Test plan

- `bun run test` → **19 passed** (7 existing cache + 12 new route tests)
- `bun run lint-nofix` → **clean** (required pre-commit gate; husky/lint-staged also passed on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)