### PR TITLE
fix: copy frozen Apollo results before sorting (read-only property crash)

### DIFF
--- a/src/components/common/CourseReviewBox.tsx
+++ b/src/components/common/CourseReviewBox.tsx
@@ -618,7 +618,12 @@ const CourseReviewBox = ({
   });
 
   const allProfs = data?.allProfs;
-  const reviewProfs = data?.reviewProfs.sort((a, b) => b.id - a.id);
+  // Apollo Client v3 returns frozen (immutable) query results, so copy the
+  // array before sorting — Array.prototype.sort() mutates in place and would
+  // otherwise throw "Cannot assign to read only property '0'".
+  const reviewProfs = data?.reviewProfs
+    ? [...data.reviewProfs].sort((a, b) => b.id - a.id)
+    : undefined;
 
   // eg: teaching = ['CS135': [{id: 1, code: 'john_doe', name: 'John Doe'}], 'CS136': []]
   const teaching: Record<string, ReviewProfsFragment['prof'][]> = {};

--- a/src/pages/profilePage/ShortlistBox.tsx
+++ b/src/pages/profilePage/ShortlistBox.tsx
@@ -26,7 +26,10 @@ type ShortlistBoxProps = {
 const ShortlistBox = ({ shortlistCourses }: ShortlistBoxProps) => {
   const isBrowserDesktop = useSelector(getIsBrowserDesktop);
 
-  const sortedShortlist = shortlistCourses.sort((a, b) =>
+  // Apollo Client v3 returns frozen (immutable) query results, so copy the
+  // array before sorting — Array.prototype.sort() mutates in place and would
+  // otherwise throw "Cannot assign to read only property '0'".
+  const sortedShortlist = [...shortlistCourses].sort((a, b) =>
     a.course!.code.localeCompare(b.course!.code),
   );
 


### PR DESCRIPTION
## Problem

Opening the review box (e.g. https://uwflow.com/course/cs240) throws:

```
TypeError: Cannot assign to read only property '0' of object '[object Array]'
    at Array.sort (<anonymous>)
    at CourseReviewBox.tsx
```

### Root cause

The Apollo Client v3 migration (#245) made query results **frozen / immutable**. `Array.prototype.sort()` sorts *in place*, so calling it directly on a query result mutates a frozen array and throws.

Apollo freezes results whenever `__DEV__ !== false`. The Webpack build never defines `__DEV__`, so it's `undefined` — meaning results are frozen in **production**, not just dev. That's why this crashed on the live site.

## Fix

Copy the array before sorting (`[...arr].sort(...)`) at the two sites that operate on raw Apollo results:

- **`CourseReviewBox.tsx`** — `data.reviewProfs` (the crash you hit on `/course/cs240`)
- **`ShortlistBox.tsx`** — `user.shortlist`, straight off `GetUserQuery` (would crash on the profile page)

### Scope check

I audited every in-place `.sort()` / `.reverse()` / `.splice()` in `src/`. Only these two operate on frozen Apollo results. The rest sort freshly-built arrays (reducer output, `.map()`/`.concat()`/`Object.keys()` results, locally-built schedule intervals) or already clone (`SearchClient.ts`), so they're unaffected.

`bun run lint-nofix` passes clean.

## Related

Regression tests for this bug class are in #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)