### PR TITLE
fix: debounce explore URL sync to avoid replaceState rate limit

### DIFF
--- a/src/pages/explorePage/ExplorePage.tsx
+++ b/src/pages/explorePage/ExplorePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useLocation } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
@@ -8,6 +8,7 @@ import {
   ExploreQuery,
   ExploreQueryVariables,
 } from 'generated/graphql';
+import { debounce } from 'lodash';
 import queryString from 'query-string';
 
 import { SEO_DESCRIPTIONS } from 'constants/Messages';
@@ -153,18 +154,36 @@ const ExplorePageContent = ({
     setProfCourses(['all courses'].concat(parsedProfCourses));
   }, [data, exploreAll]);
 
+  // Debounced URL sync. A slider drag fires setFilterState on every pointer
+  // move (dozens per second on touch devices); writing window.history on each
+  // one trips Safari's "100 replaceState calls / 10s" limit and throws a
+  // SecurityError. Debouncing collapses a drag into a single trailing write
+  // once the value settles, and the identity check skips no-op writes.
+  const syncUrlToHistory = useMemo(
+    () =>
+      debounce((nextUrl: string) => {
+        const currentUrl = `${window.location.pathname}${window.location.search}`;
+        if (nextUrl !== currentUrl) {
+          window.history.replaceState({}, '', nextUrl);
+        }
+      }, 150),
+    [],
+  );
+
+  // Cancel any pending write on unmount so a trailing call can't fire after the
+  // user has navigated to another route and overwrite that route's URL.
+  useEffect(() => () => syncUrlToHistory.cancel(), [syncUrlToHistory]);
+
   useEffect(() => {
     const urlQuery = queryString.stringify(filterStateToUrlQuery(filterState), {
       arrayFormat: 'comma',
       skipNull: true,
     });
 
-    window.history.replaceState(
-      {},
-      '',
+    syncUrlToHistory(
       urlQuery ? `${EXPLORE_PAGE_ROUTE}?${urlQuery}` : EXPLORE_PAGE_ROUTE,
     );
-  }, [filterState]);
+  }, [filterState, syncUrlToHistory]);
 
   return (
     <ExplorePageWrapper>


### PR DESCRIPTION
## Problem

Sentry issue `6983782710` — `SecurityError: Attempt to use history.replaceState() more than 100 times per 10 seconds` (DOMException 18), Mobile Safari, transaction `/explore`.

### Root cause

`ExplorePageContent` mirrors filter state into the URL with `window.history.replaceState` in an effect keyed on `filterState` (`ExplorePage.tsx`). The ratings slider (`react-compound-slider`) commits straight to `filterState` on `onUpdate`, and its internal `submitUpdate` calls `onUpdate` **unconditionally on every pointer-move event** during a drag — not only when the snapped value changes:

```js
onTouchMove = (e) => { ...; this.submitUpdate(nextHandles); };   // every touchmove
submitUpdate(next) {
  this.setState(({handles: curr}) => {
    const handles = mode2(curr, next);
    onUpdate(handles.map(d => d.val));   // fires every move
    return { handles };
  });
}
```

`setFilterKeyVal` always builds a new `filterState` object (`{ ...prev, [key]: val }`), so React never bails out, the effect re-runs, and `replaceState` is called once per move. On Mobile Safari `touchmove` fires ~60×/sec, so ~1.5–2s of dragging the "Min # of ratings" slider crosses the 100-calls-per-10s limit and throws.

## Fix

- **Debounce** the history write (150ms trailing) via `lodash.debounce`, so a continuous drag collapses into a single write once the value settles.
- **Idempotent guard**: skip the write when the target URL already equals the current one.
- **Cancel on unmount** so a pending trailing call can't fire after the user navigates away and overwrite another route's URL.

Live result filtering is unaffected — it's driven by `filterState`, which still updates on every move; only the URL sync is debounced.

## Testing

- `bun run lint-nofix` — clean
- `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)