### PR TITLE
Centralize style mixins in the global theme and Tailwind

### DIFF
--- a/src/constants/GlobalTheme.tsx
+++ b/src/constants/GlobalTheme.tsx
@@ -1,10 +1,222 @@
-import { BREAKPOINT_WIDTH, PAGE_CONTENT_WIDTH } from './PageConstants';
+import { keyframes } from 'styled-components';
+
+import {
+  BREAKPOINT_WIDTH,
+  FOOTER_HEIGHT,
+  FOOTER_MARGIN_TOP,
+  PAGE_CONTENT_WIDTH,
+} from './PageConstants';
+
+const primaryExtraDark = '#042049';
+const white = '#ffffff';
+
+const breakpoints = {
+  zero: 0,
+  mobileLarge: 600,
+  tablet: BREAKPOINT_WIDTH,
+  desktop: PAGE_CONTENT_WIDTH,
+};
+
+const fontFamily = {
+  inter:
+    'Inter, -apple-system, BlinkMacSystemFont, San Francisco, Roboto, Segoe UI, Helvetica Neue, sans-serif',
+  anderson:
+    "'Anderson Grotesk', -apple-system, BlinkMacSystemFont, San Francisco, Roboto, Segoe UI, Helvetica Neue, sans-serif",
+};
+
+const fontSize = {
+  xs: '12px',
+  s: '14px',
+  md: '16px',
+  lg: '18px',
+  xl: '20px',
+  heading2Mobile: '28px',
+  heading2: '32px',
+  heading1: '40px',
+};
+
+const fontWeight = {
+  light: 300,
+  regular: 400,
+  semibold: 600,
+  extrabold: 800,
+};
+
+const zIndex = {
+  pageContent: -1,
+  modal: 2000,
+};
+
+const borderRadius = {
+  card: '4px',
+};
+
+const shadows = {
+  box: `0px 2px 5px rgba(236, 237, 237, 0.4),
+    0px 0px 5px rgba(142, 147, 148, 0.2)`,
+  darkBox: `0px 0px 10px ${primaryExtraDark}`,
+  bottomBox: `0px 1px 3px rgba(236, 237, 237, 0.4),
+    0px 1px 3px rgba(142, 147, 148, 0.2)`,
+  text: `0px 2px 5px rgba(236, 237, 237, 0.4),
+    0px 0px 5px rgba(142, 147, 148, 0.2)`,
+};
+
+const transitions = {
+  hoverDuration: '0.1s',
+  hoverTimingFunction: 'ease-in',
+};
+
+const hoverBrightness = {
+  default: '85%',
+  dark: '60%',
+};
+
+const layout = {
+  pageMinHeight: `calc(100vh - ${FOOTER_HEIGHT}px - ${FOOTER_MARGIN_TOP}px)`,
+  pageContentWidth: `${PAGE_CONTENT_WIDTH}px`,
+  pagePadding: '32px',
+  wideColumnWidth: '70%',
+  thinColumnWidth: '30%',
+};
+
+const typography = {
+  heading1: `
+    font-family: ${fontFamily.anderson};
+    font-size: ${fontSize.heading1};
+    font-weight: ${fontWeight.extrabold};
+
+    @media only screen and (max-width: ${breakpoints.tablet}px) {
+      font-size: ${fontSize.heading2};
+    }
+  `,
+  heading2: `
+    font-family: ${fontFamily.anderson};
+    font-size: ${fontSize.heading2};
+    font-weight: ${fontWeight.extrabold};
+
+    @media only screen and (max-width: ${breakpoints.tablet}px) {
+      font-size: ${fontSize.heading2Mobile};
+    }
+  `,
+  heading3: `
+    font-family: ${fontFamily.anderson};
+    font-size: ${fontSize.xl};
+    font-weight: ${fontWeight.semibold};
+  `,
+  heading4: `
+    font-family: ${fontFamily.anderson};
+    font-size: ${fontSize.lg};
+    font-weight: ${fontWeight.semibold};
+  `,
+  body: `
+    font-family: ${fontFamily.inter};
+    font-weight: ${fontWeight.regular};
+    font-size: ${fontSize.md};
+  `,
+  small: `
+    font-weight: ${fontWeight.light};
+    font-size: ${fontSize.s};
+  `,
+};
+
+const hoverTransition = (target = 'all', time = transitions.hoverDuration) => `
+  transition: ${target} ${time} ${transitions.hoverTimingFunction};
+`;
+
+const hover = (darker = false) => `
+  ${hoverTransition()}
+  &:hover, &:focus {
+    cursor: pointer;
+    filter: brightness(${
+      darker ? hoverBrightness.dark : hoverBrightness.default
+    });
+  }
+`;
+
+const mixins = {
+  pageContentZIndex: `z-index: ${zIndex.pageContent};`,
+  pageWrapper: `
+    min-height: ${layout.pageMinHeight};
+    display: flex;
+    flex-direction: column;
+    padding-bottom: ${layout.pagePadding};
+    width: 100vw;
+  `,
+  pageContent: `
+    max-width: ${layout.pageContentWidth};
+    width: 100%;
+    margin: 0 auto;
+
+    padding-left: ${layout.pagePadding};
+    padding-right: ${layout.pagePadding};
+
+    @media only screen and (max-width: ${breakpoints.tablet - 1}px) {
+      padding-left: 0;
+      padding-right: 0;
+    }
+  `,
+  modalZIndex: `z-index: ${zIndex.modal};`,
+  wideColumn: `
+    display: flex;
+    flex-direction: column;
+    padding-right: ${layout.pagePadding};
+    width: ${layout.wideColumnWidth};
+  `,
+  thinColumn: `
+    display: flex;
+    flex-direction: column;
+    width: ${layout.thinColumnWidth};
+  `,
+  hoverTransition,
+  hover,
+  link: `
+    font-weight: ${fontWeight.semibold};
+    font-size: ${fontSize.md};
+    text-decoration: underline;
+    cursor: pointer;
+    width: fit-content;
+    ${hover(true)}
+  `,
+  boxShadow: `
+    box-shadow: ${shadows.box};
+  `,
+  darkBoxShadow: `
+    box-shadow: ${shadows.darkBox};
+  `,
+  bottomBoxShadow: `
+    box-shadow: ${shadows.bottomBox};
+  `,
+  textShadow: `
+    text-shadow: ${shadows.text};
+  `,
+  card: (padding = layout.pagePadding, margin = '0') => `
+    display: flex;
+    flex-direction: column;
+    border-radius: ${borderRadius.card};
+    width: 100%;
+    border-radius: ${borderRadius.card};
+    padding: ${padding};
+    margin: ${margin};
+    background-color: ${white};
+  `,
+};
+
+const animations = {
+  fadeIn: keyframes`
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  `,
+};
 
 export default {
   /* Colours */
   primary: '#0052cc',
   primaryDark: '#0747a6',
-  primaryExtraDark: '#042049',
+  primaryExtraDark,
   courses: '#ff8b00',
   professors: '#36b37e',
   accent: '#ffc400',
@@ -23,7 +235,7 @@ export default {
   lab: '#b3f3ff',
   tutorial: '#c0b6f2',
 
-  white: '#ffffff',
+  white,
   red: '#ff5630',
   darkRed: '#de350b',
 
@@ -32,10 +244,18 @@ export default {
 
   transparent: 'rgba(0,0,0,0)',
 
-  breakpoints: {
-    zero: 0,
-    mobileLarge: 600,
-    tablet: BREAKPOINT_WIDTH,
-    desktop: PAGE_CONTENT_WIDTH,
-  },
+  breakpoints,
+
+  fontFamily,
+  fontSize,
+  fontWeight,
+  zIndex,
+  borderRadius,
+  shadows,
+  transitions,
+  hoverBrightness,
+  layout,
+  typography,
+  mixins,
+  animations,
 };

--- a/src/constants/Mixins.tsx
+++ b/src/constants/Mixins.tsx
@@ -1,154 +1,31 @@
-import { keyframes } from 'styled-components';
-
 import theme from './GlobalTheme';
-import {
-  FOOTER_HEIGHT,
-  FOOTER_MARGIN_TOP,
-  PAGE_CONTENT_WIDTH,
-} from './PageConstants';
 
-export const InterFont = `Inter, -apple-system, BlinkMacSystemFont, San Francisco, Roboto, Segoe UI, Helvetica Neue, sans-serif`;
-export const AndersonFont = `'Anderson Grotesk', -apple-system, BlinkMacSystemFont, San Francisco, Roboto, Segoe UI, Helvetica Neue, sans-serif`;
+export const InterFont = theme.fontFamily.inter;
+export const AndersonFont = theme.fontFamily.anderson;
 
-export const PageContentZIndex = 'z-index: -1;';
+export const PageContentZIndex = theme.mixins.pageContentZIndex;
+export const PageWrapper = theme.mixins.pageWrapper;
+export const PageContent = theme.mixins.pageContent;
+export const ModalZIndex = theme.mixins.modalZIndex;
+export const WideColumn = theme.mixins.wideColumn;
+export const ThinColumn = theme.mixins.thinColumn;
 
-export const PageWrapper = `
-  min-height: calc(100vh - ${FOOTER_HEIGHT}px - ${FOOTER_MARGIN_TOP}px);
-  display: flex;
-  flex-direction: column;
-  padding-bottom: 32px;
-  width: 100vw;
-`;
+export const Heading1 = theme.typography.heading1;
+export const Heading2 = theme.typography.heading2;
+export const Heading3 = theme.typography.heading3;
+export const Heading4 = theme.typography.heading4;
+export const Body = theme.typography.body;
+export const Small = theme.typography.small;
 
-export const PageContent = `
-  max-width: ${PAGE_CONTENT_WIDTH}px;
-  width: 100%;
-  margin: 0 auto;
+export const HoverTransition = theme.mixins.hoverTransition;
+export const Hover = theme.mixins.hover;
+export const Link = theme.mixins.link;
 
-  padding-left: 32px;
-  padding-right: 32px;
+export const BoxShadow = theme.mixins.boxShadow;
+export const DarkBoxShadow = theme.mixins.darkBoxShadow;
+export const BottomBoxShadow = theme.mixins.bottomBoxShadow;
+export const TextShadow = theme.mixins.textShadow;
 
-  @media only screen and (max-width: ${theme.breakpoints.tablet - 1}px) {
-    padding-left: 0;
-    padding-right: 0;
-  }
-`;
+export const Card = theme.mixins.card;
 
-export const ModalZIndex = 'z-index: 2000;';
-
-export const WideColumn = `
-  display: flex;
-  flex-direction: column;
-  padding-right: 32px;
-  width: 70%;
-`;
-
-export const ThinColumn = `
-  display: flex;
-  flex-direction: column;
-  width: 30%;
-`;
-
-/* Fonts */
-export const Heading1 = `
-  font-family: ${AndersonFont};
-  font-size: 40px;
-  font-weight: 800;
-
-  @media only screen and (max-width: ${theme.breakpoints.tablet}px) {
-    font-size: 32px;
-  }
-`;
-
-export const Heading2 = `
-  font-family: ${AndersonFont};
-  font-size: 32px;
-  font-weight: 800;
-
-  @media only screen and (max-width: ${theme.breakpoints.tablet}px) {
-    font-size: 28px;
-  }
-`;
-
-export const Heading3 = `
-  font-family: ${AndersonFont};
-  font-size: 20px;
-  font-weight: 600;
-`;
-
-export const Heading4 = `
-  font-family: ${AndersonFont};
-  font-size: 18px;
-  font-weight: 600;
-`;
-
-export const Body = `
-  font-family: ${InterFont};
-  font-weight: 400;
-  font-size: 16px;
-`;
-
-export const Small = `
-  font-weight: 300;
-  font-size: 14px;
-`;
-
-export const HoverTransition = (target = 'all', time = '0.1s') => `
-  transition: ${target} ${time} ease-in;
-`;
-
-export const Hover = (darker = false) => `
-  ${HoverTransition()}
-  &:hover, &:focus {
-    cursor: pointer;
-    filter: brightness(${darker ? '60%' : '85%'});
-  }
-`;
-
-export const Link = `
-  font-weight: 600;
-  font-size: 16px;
-  text-decoration: underline;
-  cursor: pointer;
-  width: fit-content;
-  ${Hover(true)}
-`;
-
-export const BoxShadow = `
-  box-shadow: 0px 2px 5px rgba(236, 237, 237, 0.4),
-  0px 0px 5px rgba(142, 147, 148, 0.2);
-`;
-
-export const DarkBoxShadow = `
-  box-shadow: 0px 0px 10px ${theme.primaryExtraDark};
-`;
-
-export const BottomBoxShadow = `
-  box-shadow: 0px 1px 3px rgba(236, 237, 237, 0.4),
-    0px 1px 3px rgba(142, 147, 148, 0.2);
-`;
-
-export const TextShadow = `
-  text-shadow: 0px 2px 5px rgba(236, 237, 237, 0.4),
-  0px 0px 5px rgba(142, 147, 148, 0.2);
-`;
-
-export const Card = (padding = '32px', margin = '0') => `
-  display: flex;
-  flex-direction: column;
-  border-radius: 4px;
-  width: 100%;
-  border-radius: 4px;
-  padding: ${padding};
-  margin: ${margin};
-  background-color: white;
-`;
-
-export const FadeInAnimation = keyframes`
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-`;
+export const FadeInAnimation = theme.animations.fadeIn;

--- a/src/constants/TailwindMixins.ts
+++ b/src/constants/TailwindMixins.ts
@@ -1,0 +1,47 @@
+/**
+ * Tailwind class equivalents for constants/Mixins.
+ *
+ * Use these when migrating markup from styled-components. Runtime values such
+ * as custom card spacing should be composed with additional static classes.
+ */
+export const InterFont = 'font-inter';
+export const AndersonFont = 'font-anderson';
+
+export const PageContentZIndex = 'z-page-content';
+export const PageWrapper = 'flex min-h-page w-screen flex-col pb-page';
+export const PageContent = 'mx-auto w-full max-w-page px-page max-[799px]:px-0';
+export const ModalZIndex = 'z-modal';
+export const WideColumn = 'flex w-wide-column flex-col pr-page';
+export const ThinColumn = 'flex w-thin-column flex-col';
+
+export const Heading1 =
+  'font-anderson text-heading-1 font-extrabold max-[800px]:text-heading-2';
+export const Heading2 =
+  'font-anderson text-heading-2 font-extrabold max-[800px]:text-heading-2-mobile';
+export const Heading3 = 'font-anderson text-xl font-semibold';
+export const Heading4 = 'font-anderson text-lg font-semibold';
+export const Body = 'font-inter text-md font-regular';
+export const Small = 'text-s font-light';
+
+export const HoverTransition = 'transition-all duration-hover ease-hover';
+
+export const Hover = (darker = false) =>
+  `${HoverTransition} hover:cursor-pointer focus:cursor-pointer ${
+    darker
+      ? 'hover:brightness-hover-dark focus:brightness-hover-dark'
+      : 'hover:brightness-hover focus:brightness-hover'
+  }`;
+
+export const Link = `w-fit cursor-pointer text-md font-semibold underline ${Hover(
+  true,
+)}`;
+
+export const BoxShadow = 'shadow-box';
+export const DarkBoxShadow = 'shadow-dark-box';
+export const BottomBoxShadow = 'shadow-bottom-box';
+export const TextShadow = 'text-shadow';
+
+// Additional padding and margin variants should be composed at the call site.
+export const Card = 'm-0 flex w-full flex-col rounded-card bg-white p-page';
+
+export const FadeInAnimation = 'animate-fade-in';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+const plugin = require('tailwindcss/plugin');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: ['class'],
@@ -11,8 +13,7 @@ module.exports = {
   },
   theme: {
     extend: {
-      // Mirrors src/constants/GlobalTheme.tsx so styled-components and Tailwind
-      // share a single palette. Keep these two files in sync.
+      // Mirrors src/constants/GlobalTheme.tsx. Keep the two files in sync.
       colors: {
         primary: '#0052cc',
         primaryDark: '#0747a6',
@@ -51,7 +52,103 @@ module.exports = {
         tablet: '800px',
         desktop: '1200px',
       },
+      fontFamily: {
+        inter: [
+          'Inter',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'San Francisco',
+          'Roboto',
+          'Segoe UI',
+          'Helvetica Neue',
+          'sans-serif',
+        ],
+        anderson: [
+          'Anderson Grotesk',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'San Francisco',
+          'Roboto',
+          'Segoe UI',
+          'Helvetica Neue',
+          'sans-serif',
+        ],
+      },
+      fontSize: {
+        xs: '12px',
+        s: '14px',
+        md: '16px',
+        lg: '18px',
+        xl: '20px',
+        'heading-2-mobile': '28px',
+        'heading-2': '32px',
+        'heading-1': '40px',
+      },
+      fontWeight: {
+        light: '300',
+        regular: '400',
+        semibold: '600',
+        extrabold: '800',
+      },
+      spacing: {
+        page: '32px',
+      },
+      width: {
+        'wide-column': '70%',
+        'thin-column': '30%',
+      },
+      maxWidth: {
+        page: '1200px',
+      },
+      minHeight: {
+        page: 'calc(100vh - 70px - 32px)',
+      },
+      zIndex: {
+        'page-content': '-1',
+        modal: '2000',
+      },
+      borderRadius: {
+        card: '4px',
+      },
+      boxShadow: {
+        box: '0px 2px 5px rgba(236, 237, 237, 0.4), 0px 0px 5px rgba(142, 147, 148, 0.2)',
+        'dark-box': '0px 0px 10px #042049',
+        'bottom-box':
+          '0px 1px 3px rgba(236, 237, 237, 0.4), 0px 1px 3px rgba(142, 147, 148, 0.2)',
+      },
+      textShadow: {
+        DEFAULT:
+          '0px 2px 5px rgba(236, 237, 237, 0.4), 0px 0px 5px rgba(142, 147, 148, 0.2)',
+      },
+      brightness: {
+        hover: '0.85',
+        'hover-dark': '0.6',
+      },
+      transitionDuration: {
+        hover: '100ms',
+      },
+      transitionTimingFunction: {
+        hover: 'ease-in',
+      },
+      keyframes: {
+        fadeIn: {
+          from: { opacity: '0' },
+          to: { opacity: '1' },
+        },
+      },
+      animation: {
+        'fade-in': 'fadeIn 0.2s',
+      },
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  plugins: [
+    require('tailwindcss-animate'),
+    plugin(({ addUtilities, theme }) => {
+      addUtilities({
+        '.text-shadow': {
+          textShadow: theme('textShadow.DEFAULT'),
+        },
+      });
+    }),
+  ],
 };


### PR DESCRIPTION
## Summary
- move typography, layout, shadow, transition, interaction, card, z-index, and animation definitions into `GlobalTheme.tsx`
- retain `Mixins.tsx` as a compatibility facade so existing styled-components consumers keep the same imports and rendered CSS
- mirror reusable theme values into Tailwind, including fonts, sizes, weights, layout dimensions, shadows, z-indexes, hover states, transitions, and fade-in animation
- add `TailwindMixins.ts` with utility-class equivalents for incrementally migrating components from styled-components

Parameterized values such as custom card spacing remain composable with additional static Tailwind classes rather than runtime-generated class names.

## Verification
- `bun run lint-nofix`
- `./node_modules/.bin/tsc --noEmit`
- Tailwind CLI compilation with mapped utility checks
- `bun scripts/build.js` (passes with pre-existing lint and Browserslist warnings)