### PR TITLE
fix: guard against undefined error in Google login failure handler

### DIFF
--- a/src/components/auth/SocialLoginContent.tsx
+++ b/src/components/auth/SocialLoginContent.tsx
@@ -79,10 +79,13 @@ const SocialLoginContent = ({ onAuthSuccess }: SocialLoginContentProps) => {
   };
 
   const handleGoogleFailure = (res: ErrorResponse) => {
+    // react-google-login can invoke onFailure with a value that has no `error`
+    // string (e.g. when the GSI script fails to load), so guard before using it.
+    const errorCode = res?.error ?? '';
     const errorMessage =
-      res.error === 'popup_closed_by_user' ? '' : AUTH_ERRORS.no_google_email;
+      errorCode === 'popup_closed_by_user' ? '' : AUTH_ERRORS.no_google_email;
 
-    if (!res.error.includes('idpiframe')) {
+    if (!errorCode.includes('idpiframe')) {
       setError(errorMessage);
     }
   };


### PR DESCRIPTION
## Problem

Sentry issue **7518772192** (`/`, production, Safari 26.5 / Mac):

> **TypeError: undefined is not an object (evaluating 'e.error.includes')**

`react-google-login`'s `onFailure` callback can be invoked with a value whose `error` property is `undefined` — typically when the Google Identity Services script fails to initialize (commonly on Safari when third-party cookies are blocked). The declared `ErrorResponse` type assumes `error: string`, but that doesn't hold at runtime, so `res.error.includes('idpiframe')` in `handleGoogleFailure` threw.

```
onFailure in components/auth/SocialLoginContent.tsx [Line 85]
  if (!res.error.includes('idpiframe')) {   <-- res.error is undefined
```

## Fix

`src/components/auth/SocialLoginContent.tsx` — default the error code to an empty string before comparing / calling `.includes()`:

```tsx
const errorCode = res?.error ?? '';
const errorMessage =
  errorCode === 'popup_closed_by_user' ? '' : AUTH_ERRORS.no_google_email;

if (!errorCode.includes('idpiframe')) {
  setError(errorMessage);
}
```

This preserves existing behavior for all known error codes and degrades gracefully (shows the generic "no Google email" message) for unknown/undefined ones instead of crashing.

## Verification

- `bun run lint-nofix` passes clean (exit 0)
- husky pre-commit lint-staged hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)