### PR TITLE
Fix all ESLint warnings (unused vars, non-null assertions)

### DIFF
--- a/src/components/display/RatingBox.tsx
+++ b/src/components/display/RatingBox.tsx
@@ -69,8 +69,8 @@ const RatingBox = ({
   const scrollToReviews = () => {
     if (numComments) {
       document
-        .getElementById(REVIEWS_DIV_ID)!
-        .scrollIntoView({ behavior: 'smooth' });
+        .getElementById(REVIEWS_DIV_ID)
+        ?.scrollIntoView({ behavior: 'smooth' });
     }
   };
 

--- a/src/components/navigation/ProfileDropdown.tsx
+++ b/src/components/navigation/ProfileDropdown.tsx
@@ -45,7 +45,7 @@ const renderProfilePicture = (
 
   return (
     <ProfilePicture
-      image={user.picture_url ? user.picture_url! : getKittenFromID(user.id)}
+      image={user.picture_url || getKittenFromID(user.id)}
       isLanding={isLanding}
       onMouseDown={(e) => e.preventDefault()}
     />

--- a/src/components/upload/TranscriptUploadModalContent.tsx
+++ b/src/components/upload/TranscriptUploadModalContent.tsx
@@ -122,8 +122,8 @@ const TranscriptUploadModalContent = ({
     e.preventDefault();
     e.stopPropagation();
 
-    if (fileInputRef && fileInputRef.current) {
-      await makeTranscriptRequest(fileInputRef.current.files![0]);
+    if (fileInputRef && fileInputRef.current && fileInputRef.current.files) {
+      await makeTranscriptRequest(fileInputRef.current.files[0]);
     }
   };
 

--- a/src/pages/coursePage/CourseInfoHeader.tsx
+++ b/src/pages/coursePage/CourseInfoHeader.tsx
@@ -43,7 +43,8 @@ const CourseInfoHeader = ({
   shortlisted,
   distributions,
 }: CourseInfoHeaderProps) => {
-  const { liked, easy, useful, filled_count, comment_count } = course.rating!;
+  const { liked, easy, useful, filled_count, comment_count } =
+    course.rating ?? ({} as NonNullable<typeof course.rating>);
   const redditSearchTerm = course.code.replace(/\s+/g, '').toLowerCase();
   const redditSearchUrl = `https://www.reddit.com/r/uwaterloo/search/?q=${encodeURIComponent(
     redditSearchTerm,

--- a/src/pages/coursePage/CoursePage.tsx
+++ b/src/pages/coursePage/CoursePage.tsx
@@ -219,14 +219,17 @@ const CoursePage = () => {
           {formatCourseCode(data.course[0].code)} - {data.course[0].name} - UW
           Flow
         </title>
-        <meta name="description" content={data.course[0].description!} />
+        <meta name="description" content={data.course[0].description ?? ''} />
         <meta
           property="og:title"
           content={`${formatCourseCode(data.course[0].code)} - ${
             data.course[0].name
           } - UW Flow`}
         />
-        <meta property="og:description" content={data.course[0].description!} />
+        <meta
+          property="og:description"
+          content={data.course[0].description ?? ''}
+        />
       </Helmet>
       {renderContent(data)}
     </CoursePageWrapper>

--- a/src/pages/coursePage/CourseSchedule.tsx
+++ b/src/pages/coursePage/CourseSchedule.tsx
@@ -67,8 +67,8 @@ const getInfoGroupings = (meetings: Meeting[]) => {
       const key = `${curr.start_seconds} ${curr.end_seconds}`;
       if (!groupings[key]) {
         groupings[key] = {
-          time: `${secsToTime(curr.start_seconds!)} - ${secsToTime(
-            curr.end_seconds!,
+          time: `${secsToTime(curr.start_seconds ?? 0)} - ${secsToTime(
+            curr.end_seconds ?? 0,
           )}`,
           location: curr.location,
           prof:

--- a/src/pages/explorePage/SearchResults.tsx
+++ b/src/pages/explorePage/SearchResults.tsx
@@ -31,10 +31,6 @@ const nextTermCode = getNextTermCode();
 // dirties the URL.
 const DEFAULT_SORT_BY: TableSortBy = { id: 'ratings', desc: false };
 
-// Sort keys that only exist on course rows; applying them to prof rows would
-// produce undefined values and crash stringSort.
-const COURSE_ONLY_SORT_KEYS = ['code', 'name'];
-
 // 'name' -> asc, '-name' -> desc, '' -> default sort.
 const parseSortBy = (sortBy: string): TableSortBy[] => {
   if (!sortBy) return [DEFAULT_SORT_BY];
@@ -130,9 +126,9 @@ const SearchResults = ({
       : (data as ExploreQuery).search_profs;
 
     const newCourses: CourseSearchResult[] = allCourses.map((result) => ({
-      id: result.course_id!,
-      code: result.code!,
-      name: result.name!,
+      id: result.course_id ?? 0,
+      code: result.code ?? '',
+      name: result.name ?? '',
       ratings: result.ratings,
       liked: result.liked,
       easy: result.easy,
@@ -144,10 +140,10 @@ const SearchResults = ({
     }));
 
     const newProfs: ProfSearchResult[] = allProfs.map((result) => ({
-      id: result.prof_id!,
+      id: result.prof_id ?? 0,
       code_name: {
-        code: result.code!,
-        name: result.name!,
+        code: result.code ?? '',
+        name: result.name ?? '',
       },
       ratings: result.ratings,
       liked: result.liked,

--- a/src/pages/profilePage/ProfileCourses.tsx
+++ b/src/pages/profilePage/ProfileCourses.tsx
@@ -89,12 +89,13 @@ const ProfileCourses = ({
     });
 
   const sortedCourseList = reviewModalCourseList.sort((a, b) =>
-    a.course!.code.localeCompare(b.course!.code),
+    (a.course?.code ?? '').localeCompare(b.course?.code ?? ''),
   );
 
   const tabContent = (termName: string): ReactNode =>
     courseGroups[termName].map((courseTaken) => {
-      const course = courseTaken.course!;
+      const course = courseTaken.course;
+      if (!course) return null;
       const review = reviews.find((r) => r.course_id === courseTaken.course_id);
       const selectedIndex = sortedCourseList.findIndex(
         (courseObj) => courseObj.course?.id === courseTaken.course?.id,
@@ -110,7 +111,7 @@ const ProfileCourses = ({
           </ProfileCourseText>
           <LikedCourseWrapper>
             <ProfileCourseLiked>
-              {processRating(course.rating!.liked)}
+              {processRating(course.rating?.liked ?? 0)}
             </ProfileCourseLiked>
             <LikedThisCourseText>
               liked this

--- a/src/pages/profilePage/ShortlistBox.tsx
+++ b/src/pages/profilePage/ShortlistBox.tsx
@@ -30,27 +30,31 @@ const ShortlistBox = ({ shortlistCourses }: ShortlistBoxProps) => {
   // array before sorting — Array.prototype.sort() mutates in place and would
   // otherwise throw "Cannot assign to read only property '0'".
   const sortedShortlist = [...shortlistCourses].sort((a, b) =>
-    a.course!.code.localeCompare(b.course!.code),
+    (a.course?.code ?? '').localeCompare(b.course?.code ?? ''),
   );
 
   const shorlistContent = (
     <>
-      {sortedShortlist.map((entry, idx) => (
-        <ShortlistCourse key={idx}>
-          <ShortlistStar
-            key={entry.course!.id}
-            initialState={true}
-            courseId={entry.course!.id}
-            courseCode={entry.course!.code}
-          />
-          <ShortListCourseText>
-            <ShortlistCourseCode to={getCoursePageRoute(entry.course!.code)}>
-              {formatCourseCode(entry.course!.code)}
-            </ShortlistCourseCode>
-            <ShortlistCourseName>{entry.course!.name}</ShortlistCourseName>
-          </ShortListCourseText>
-        </ShortlistCourse>
-      ))}
+      {sortedShortlist.map((entry, idx) => {
+        const { course } = entry;
+        if (!course) return null;
+        return (
+          <ShortlistCourse key={idx}>
+            <ShortlistStar
+              key={course.id}
+              initialState={true}
+              courseId={course.id}
+              courseCode={course.code}
+            />
+            <ShortListCourseText>
+              <ShortlistCourseCode to={getCoursePageRoute(course.code)}>
+                {formatCourseCode(course.code)}
+              </ShortlistCourseCode>
+              <ShortlistCourseName>{course.name}</ShortlistCourseName>
+            </ShortListCourseText>
+          </ShortlistCourse>
+        );
+      })}
       {shortlistCourses.length === 0 ? (
         <ShortlistCourse>
           <ShortlistCoursePlaceholder>

--- a/src/search/SearchClient.ts
+++ b/src/search/SearchClient.ts
@@ -151,7 +151,10 @@ class SearchClient {
     let indexedDate = lastIndexedDate;
 
     if (searchData !== null) {
-      parsedSearchData = JSON.parse(LZString.decompressFromUTF16(searchData)!);
+      const decompressed = LZString.decompressFromUTF16(searchData);
+      if (decompressed !== null) {
+        parsedSearchData = JSON.parse(decompressed);
+      }
     }
 
     // Fetch data if not available from local storage

--- a/src/types/Common.tsx
+++ b/src/types/Common.tsx
@@ -1,4 +1,3 @@
-import React, { Dispatch, SetStateAction, useEffect } from 'react';
 import { Moment } from 'moment';
 
 /* Table */

--- a/src/utils/Review.tsx
+++ b/src/utils/Review.tsx
@@ -25,7 +25,7 @@ export const sortReviews = (reviews: any[], sortByTime: boolean): any[] => {
 export const sortByReviews = (
   a_reviews: any,
   b_reviews: any,
-  defaultSort = (a: any, b: any) => 0,
+  defaultSort: (a: any, b: any) => number = () => 0,
 ) =>
   a_reviews.reviews.length === b_reviews.reviews.length
     ? defaultSort(a_reviews, b_reviews)


### PR DESCRIPTION
## Summary

Resolves the **34 ESLint warnings** reported by `eslint src/` so the full lint run is clean. The CI gate `bun run lint-nofix` already passed (these were warnings, not errors), but this clears the remaining noise across the codebase.

Changes span 12 files in two categories:

**Unused vars/imports (6)**
- `types/Common.tsx` — removed dead `import React, { Dispatch, SetStateAction, useEffect }` (only `Moment` was used).
- `utils/Review.tsx` — typed `defaultSort` as `(a, b) => number = () => 0` so the no-op default keeps its 2-arg call signature without unused params.
- `explorePage/SearchResults.tsx` — removed the unused `COURSE_ONLY_SORT_KEYS` constant.

**`no-non-null-assertion` (28)** — replaced `!` with behavior-preserving alternatives:
- `?? 0` / `?? ''` fallbacks for nullable GraphQL fields (`SearchResults`, `CourseSchedule`, `CoursePage`, `CourseInfoHeader`).
- `const x = …; if (!x) return null;` narrowing in map bodies (`ShortlistBox`, `ProfileCourses`).
- Optional chaining / `||` for DOM and optional access (`RatingBox`, `ProfileDropdown`, `TranscriptUploadModalContent`).

## Behavior

No type or runtime behavior change in practice — each fallback only differs from the old assertion when the value is actually `null`, paths the assertions claimed never occur.

## Verification
- `eslint src/` → **0 problems** (was 34 warnings)
- `bun run lint-nofix` → exits clean
- `tsc --noEmit` → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)