### PR TITLE
feat(analytics): frontend event tracking + PostHog Cloud dual-send

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,28 @@
+# UW Flow frontend environment variables (Create React App).
+#
+# Copy to `.env.local` (gitignored) for local overrides, or set these in your
+# deployment provider's env config. Only variables prefixed REACT_APP_ are
+# inlined into the client bundle at build time (see config/env.js).
+
+# --- Backend endpoints -------------------------------------------------------
+# Absolute base URL of the custom Go backend (non-GraphQL) API. When unset:
+#   - development -> http://localhost:8081
+#   - production  -> /api   (same-origin; proxied to the backend — see vercel.json)
+# All custom backend calls (auth, parse, search data, AND analytics /events)
+# are built as `${REACT_APP_BACKEND_ENDPOINT}/<path>`.
+# REACT_APP_BACKEND_ENDPOINT=https://uwflow.com/api
+
+# Absolute URL of the Hasura GraphQL endpoint. When unset:
+#   - development -> http://localhost:8080/v1/graphql
+#   - production  -> /graphql
+# REACT_APP_GRAPHQL_ENDPOINT=https://uwflow.com/graphql
+
+# --- Analytics: PostHog Cloud (dual-send) ------------------------------------
+# Public PostHog project API key. Safe to expose in client JS. When UNSET,
+# PostHog is a no-op (the local /events ingestion still runs) — this is the
+# expected state for local dev.
+# REACT_APP_POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# PostHog ingestion host. Defaults to https://us.i.posthog.com when unset.
+# Use https://eu.i.posthog.com for EU cloud, or your self-hosted host.
+# REACT_APP_POSTHOG_HOST=https://us.i.posthog.com

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Clone the [backend repository](https://github.com/UWFlow/uwflow) and follow its 
 - [Using and creating modals](docs/modals.md)
 - [Creating new pages](docs/pages.md)
 - [Explanation of client-side search](docs/search.md)
+- [Events analytics pipeline](docs/analytics.md)
 
 #### Important External Docs
 

--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "postcss-normalize": "10.0.1",
         "postcss-preset-env": "^7.8.3",
         "postcss-safe-parser": "4.0.1",
+        "posthog-js": "^1.387.0",
         "prop-types": "^15.7.2",
         "query-string": "^6.10.1",
         "react": "^18.3.1",
@@ -610,6 +611,10 @@
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
 
+    "@posthog/core": ["@posthog/core@1.33.0", "", { "dependencies": { "@posthog/types": "^1.387.0" } }, "sha512-Xk5O4g70SlsodD941j5GJTto2DgteKslmuhQ1kH5nR03JVOgdOw7rBesyWGhYkEdkxr8Vhvx33f1NTEZgejL2A=="],
+
+    "@posthog/types": ["@posthog/types@1.387.0", "", {}, "sha512-XR0B1geABbnUlSNv4RuFWvk19D870B668C/XzcKDctAZ+xCH5gmGM0oltGbA9yj+2ia9Y65nOrDYKN6Whu1oBw=="],
+
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", {}, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" } }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
@@ -767,6 +772,8 @@
     "@types/stack-utils": ["@types/stack-utils@1.0.1", "", {}, "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="],
 
     "@types/styled-components": ["@types/styled-components@5.1.36", "", { "dependencies": { "@types/hoist-non-react-statics": "*", "@types/react": "*", "csstype": "^3.2.2" } }, "sha512-pGMRNY5G2rNDKEv2DOiFYa7Ft1r0jrhmgBwHhOMzPTgCjO76bCot0/4uEfqj7K0Jf1KdQmDtAuaDk9EAs9foSw=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -1222,7 +1229,7 @@
 
     "copy-descriptor": ["copy-descriptor@0.1.1", "", {}, "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="],
 
-    "core-js": ["core-js@3.6.5", "", {}, "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="],
+    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
 
     "core-js-compat": ["core-js-compat@3.6.5", "", { "dependencies": { "browserslist": "^4.8.5", "semver": "7.0.0" } }, "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng=="],
 
@@ -1409,6 +1416,8 @@
     "domexception": ["domexception@1.0.1", "", { "dependencies": { "webidl-conversions": "^4.0.2" } }, "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug=="],
 
     "domhandler": ["domhandler@2.4.2", "", { "dependencies": { "domelementtype": "1" } }, "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA=="],
+
+    "dompurify": ["dompurify@3.4.10", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w=="],
 
     "domutils": ["domutils@1.7.0", "", { "dependencies": { "dom-serializer": "0", "domelementtype": "1" } }, "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg=="],
 
@@ -1603,6 +1612,8 @@
     "fdir": ["fdir@6.5.0", "", {}, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "figgy-pudding": ["figgy-pudding@3.5.2", "", {}, "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="],
 
@@ -2662,6 +2673,10 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
+    "posthog-js": ["posthog-js@1.387.0", "", { "dependencies": { "@posthog/core": "^1.33.0", "@posthog/types": "^1.387.0", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-Pv1jUMySMN62zoAxdJBJPV8n62lkHdjuWhpeU7izczc5Dqbx3hhqO2hkrNTI8Yx1ezmWk2qUHZs03FuOBubdFQ=="],
+
+    "preact": ["preact@10.29.2", "", {}, "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prepend-http": ["prepend-http@1.0.4", "", {}, "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="],
@@ -2711,6 +2726,8 @@
     "q": ["q@1.5.1", "", {}, "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="],
 
     "qs": ["qs@6.7.0", "", {}, "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "query-string": ["query-string@6.14.1", "", { "dependencies": { "decode-uri-component": "^0.2.0", "filter-obj": "^1.1.0", "split-on-first": "^1.0.0", "strict-uri-encode": "^2.0.0" } }, "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw=="],
 
@@ -3361,6 +3378,8 @@
     "wbuf": ["wbuf@1.7.3", "", { "dependencies": { "minimalistic-assert": "^1.0.0" } }, "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
 
     "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
 
@@ -4418,6 +4437,8 @@
 
     "raw-body/http-errors": ["http-errors@1.7.2", "", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.3", "setprototypeof": "1.1.1", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.0" } }, "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg=="],
 
+    "react-app-polyfill/core-js": ["core-js@3.6.5", "", {}, "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="],
+
     "react-dev-utils/@babel/code-frame": ["@babel/code-frame@7.8.3", "", { "dependencies": { "@babel/highlight": "^7.8.3" } }, "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g=="],
 
     "react-dev-utils/browserslist": ["browserslist@4.10.0", "", { "dependencies": { "caniuse-lite": "^1.0.30001035", "electron-to-chromium": "^1.3.378", "node-releases": "^1.1.52", "pkg-up": "^3.1.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-TpfK0TDgv71dzuTsEAlQiHeWQ/tiPqgNZVdv046fvNtBZrjbv2O3TsWCDU0AWGJJKCF/KsjNdLzR9hXOsh/CfA=="],
@@ -4465,8 +4486,6 @@
     "realpath-native/util.promisify": ["util.promisify@1.0.1", "", { "dependencies": { "define-properties": "^1.1.3", "es-abstract": "^1.17.2", "has-symbols": "^1.0.1", "object.getownpropertydescriptors": "^2.1.0" } }, "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA=="],
 
     "recharts/classnames": ["classnames@2.5.1", "", {}, "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="],
-
-    "recharts/core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
 
     "recursive-readdir/minimatch": ["minimatch@3.0.4", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="],
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,113 @@
+# Analytics
+
+UW Flow's events-analytics pipeline. The frontend **dual-sends** every tracked
+event to two destinations:
+
+1. **Our own ingestion endpoint** (`POST /events` on the Go backend) — the raw
+   store. The backend writes events to ClickHouse and archives them to S3.
+2. **PostHog Cloud** (`posthog.capture`) — product dashboards, funnels, and
+   retention.
+
+PostHog is for analysis surfaces; our endpoint is the source of truth. The two
+receive the same events so they can be reconciled.
+
+## Client architecture
+
+Everything lives under [`src/lib/analytics/`](../src/lib/analytics):
+
+| File                 | Responsibility                                              |
+|----------------------|-------------------------------------------------------------|
+| `types.ts`           | Event taxonomy (`EventName`), `props`, and wire types.      |
+| `ids.ts`             | `anonymous_id` + `session_id` management, uuid v4 generator.|
+| `posthog.ts`         | Lazy-init PostHog dual-send (no-ops when no key).           |
+| `client.ts`          | Buffer + batched flush to `/events`, DNT guard, singleton.  |
+| `usePageTracking.ts` | Route-change hook: `session_start`, `page_view`, `page_dwell`.|
+| `index.ts`           | Public API barrel.                                          |
+
+### Identity
+
+- `anonymous_id` — uuid v4 persisted in `localStorage`
+  (`uwflow_analytics_anonymous_id`). Stable across sessions/tabs.
+- `session_id` — uuid v4 in `sessionStorage` (`uwflow_analytics_session_id`),
+  regenerated after **~30 minutes of inactivity**.
+
+### Buffering & delivery
+
+- `track(name, props?)` enqueues an event in an in-memory buffer.
+- The buffer auto-flushes every **~5 s**, or immediately when it hits **10**
+  events.
+- On `visibilitychange → hidden`, `pagehide`, and `beforeunload`, the buffer is
+  flushed via `navigator.sendBeacon` so in-flight events survive navigation.
+- Normal flushes use a `keepalive` `fetch`. Failed sends are re-queued.
+- Analytics is wrapped so it **can never throw into the React tree or block
+  navigation**, and it becomes a silent no-op when `navigator.doNotTrack` is
+  set.
+
+## Ingestion contract
+
+`POST <BACKEND_ENDPOINT>/events`, `Content-Type: application/json`. The backend
+responds `202`; the body is ignored.
+
+```json
+{
+  "events": [
+    {
+      "name": "course_view",
+      "ts": 1718500000000,
+      "anonymous_id": "uuid-v4",
+      "session_id": "uuid-v4",
+      "url": "/course/cs246",
+      "referrer": "/explore",
+      "props": { "course_code": "cs246" }
+    }
+  ]
+}
+```
+
+- `name` — snake_case, ≤ 64 chars.
+- `ts` — epoch millis (`Date.now()`).
+- `url` — `location.pathname + location.search`.
+- `referrer` — previous in-app path (falls back to `document.referrer`).
+- `props` — flat object of `string | number | boolean` (nested values are
+  coerced/stripped client-side).
+
+### How the ingestion URL is resolved
+
+The client appends `/events` to the **same `BACKEND_ENDPOINT` constant** every
+other custom (non-GraphQL) backend call uses — see
+[`src/constants/Api.tsx`](../src/constants/Api.tsx). No domain is hardcoded:
+
+| Environment | `BACKEND_ENDPOINT` | POST target              |
+|-------------|--------------------|--------------------------|
+| development | `http://localhost:8081` | `http://localhost:8081/events` |
+| production  | `/api` (same-origin, proxied — see `vercel.json` rewrites) | `/api/events` |
+| override    | `REACT_APP_BACKEND_ENDPOINT` | `${REACT_APP_BACKEND_ENDPOINT}/events` |
+
+## Event taxonomy (v1)
+
+| Event           | When                                   | Key props                                | Instrumented in |
+|-----------------|----------------------------------------|------------------------------------------|-----------------|
+| `session_start` | Once per session (tracker mount)       | —                                        | `usePageTracking` |
+| `page_view`     | Every route change                     | `path`                                   | `usePageTracking` |
+| `page_dwell`    | On navigate-away + tab hide/unload     | `path`, `dwell_ms`                       | `usePageTracking` |
+| `course_view`   | Course page mounts                     | `course_code`                            | `pages/coursePage/CoursePage.tsx` |
+| `course_search` | Debounced explore search settles       | `query`, `results_count`, `code_search`  | `pages/explorePage/ExplorePage.tsx` |
+| `review_view`   | Course reviews load                    | `course_id`, `review_count`              | `pages/coursePage/CourseReviews.tsx` |
+| `profile_view`  | Professor profile page mounts          | `prof_code`                              | `pages/profPage/ProfPage.tsx` |
+
+`page_dwell.dwell_ms` is the client-measured residence time per page; the
+backend averages these to compute "average retention time".
+
+## Environment variables
+
+Set these for the deploy (see [`.env.sample`](../.env.sample)). All are
+build-time `REACT_APP_*` vars inlined by CRA.
+
+| Variable                  | Required | Default                     | Purpose |
+|---------------------------|----------|-----------------------------|---------|
+| `REACT_APP_POSTHOG_KEY`   | No       | _(unset → PostHog disabled)_ | Public PostHog project API key. When unset, only the `/events` ingestion runs (expected in local dev). |
+| `REACT_APP_POSTHOG_HOST`  | No       | `https://us.i.posthog.com`  | PostHog ingestion host (use `https://eu.i.posthog.com` for EU). |
+| `REACT_APP_BACKEND_ENDPOINT` | No    | `/api` (prod) / `localhost:8081` (dev) | Backend base; `/events` is appended for ingestion. |
+
+The PostHog key is public by design (a key in client JS can't be secret). The
+`/events` endpoint intentionally has **no** API key — it just accepts JSON.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "postcss-normalize": "10.0.1",
     "postcss-preset-env": "^7.8.3",
     "postcss-safe-parser": "4.0.1",
+    "posthog-js": "^1.387.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.10.1",
     "react": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import {
 import { SEO_DESCRIPTIONS } from 'constants/Messages';
 import { RootState } from 'data/reducers/RootReducer';
 import LandingPageBg from 'img/landing.svg';
+import { initAnalytics, usePageTracking } from 'lib/analytics';
 import { AuthRefreshResponse } from 'types/Api';
 import { makeAuthenticatedPOSTRequest } from 'utils/Api';
 import { getUserId } from 'utils/Auth';
@@ -50,10 +51,15 @@ import 'react-toastify/dist/ReactToastify.css';
 
 Modal.setAppElement('#root');
 ReactGA.initialize(GOOGLE_ANALYTICS_ID);
+initAnalytics();
 
 const App = () => {
   const isLoggedIn = useSelector((state: RootState) => state.auth.loggedIn);
   const location = useLocation();
+
+  // Route-level analytics: session_start, page_view, and page_dwell. Mounted
+  // here, inside <Router>, so useLocation fires on every navigation.
+  usePageTracking();
 
   // Refresh auth token if logged in
   useEffect(() => {

--- a/src/lib/analytics/client.ts
+++ b/src/lib/analytics/client.ts
@@ -1,0 +1,274 @@
+/**
+ * Analytics client — the single entry point the rest of the app uses.
+ *
+ * Responsibilities:
+ *   1. Buffer tracked events in memory and flush them in batches to our own
+ *      ingestion endpoint (POST <BACKEND_ENDPOINT>/events). This is the raw
+ *      store (ClickHouse + S3 archival on the backend).
+ *   2. Dual-send every event to PostHog Cloud for product dashboards.
+ *
+ * Design constraints (hard requirements):
+ *   - Analytics must NEVER throw into the React tree or block navigation. Every
+ *     public method is wrapped so a failure is swallowed (optionally logged).
+ *   - Respect navigator.doNotTrack: when set, the client becomes a no-op.
+ *   - On page unload / tab hide, flush via navigator.sendBeacon so in-flight
+ *     events survive the navigation.
+ *
+ * The ingestion base URL is resolved through the SAME mechanism every other
+ * custom (non-GraphQL) backend call uses: the `BACKEND_ENDPOINT` constant
+ * (constants/Api.tsx), which is `/api` in production (proxied to the Go backend
+ * — see vercel.json rewrites) and http://localhost:8081 in development, with a
+ * REACT_APP_BACKEND_ENDPOINT override. We simply append `/events`.
+ */
+
+import { BACKEND_ENDPOINT } from 'constants/Api';
+
+import { getAnonymousId, getSession } from './ids';
+import { capturePostHog, identifyPostHog, isPostHogEnabled } from './posthog';
+import type {
+  AnalyticsEvent,
+  EventName,
+  EventProps,
+  IngestBody,
+} from './types';
+
+/** Path appended to BACKEND_ENDPOINT for the ingestion endpoint. */
+const EVENTS_ENDPOINT = '/events';
+
+/** Flush when the buffer reaches this many events. */
+const FLUSH_BATCH_SIZE = 10;
+/** Periodic auto-flush interval. */
+const FLUSH_INTERVAL_MS = 5000;
+/** Cap the buffer so a long offline period can't grow it without bound. */
+const MAX_BUFFER_SIZE = 100;
+
+const ingestUrl = (): string => `${BACKEND_ENDPOINT}${EVENTS_ENDPOINT}`;
+
+/**
+ * Honour the user's Do-Not-Track preference. Checked once at module init; if the
+ * user enabled DNT, the whole client becomes a silent no-op.
+ */
+const isDoNotTrack = (): boolean => {
+  try {
+    const nav = navigator as Navigator & {
+      msDoNotTrack?: string;
+    };
+    const win = window as Window & { doNotTrack?: string };
+    const dnt = nav.doNotTrack || win.doNotTrack || nav.msDoNotTrack;
+    return dnt === '1' || dnt === 'yes';
+  } catch {
+    return false;
+  }
+};
+
+class AnalyticsClient {
+  private buffer: AnalyticsEvent[] = [];
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  private enabled = false;
+
+  private initialized = false;
+
+  /** Previous path, used as the `referrer` for the next event. */
+  private lastPath: string;
+
+  constructor() {
+    this.lastPath = this.safeReferrer();
+  }
+
+  private safeReferrer(): string {
+    try {
+      return document.referrer || '';
+    } catch {
+      return '';
+    }
+  }
+
+  private currentUrl(): string {
+    try {
+      return window.location.pathname + window.location.search;
+    } catch {
+      return '';
+    }
+  }
+
+  /**
+   * Initialize the client. Idempotent. Sets up the flush interval and the
+   * unload/visibility listeners. No-ops (leaving the client disabled) when the
+   * user has Do-Not-Track enabled.
+   */
+  init(): void {
+    if (this.initialized) {
+      return;
+    }
+    this.initialized = true;
+
+    if (isDoNotTrack()) {
+      // Stay disabled; every track() call will be a no-op.
+      return;
+    }
+
+    this.enabled = true;
+
+    try {
+      // Identify PostHog with our stable anonymous id up front.
+      if (isPostHogEnabled()) {
+        identifyPostHog(getAnonymousId());
+      }
+
+      this.timer = setInterval(() => this.flush(), FLUSH_INTERVAL_MS);
+
+      // Flush on tab hide / unload using sendBeacon so events survive nav.
+      const flushBeacon = () => this.flush(true);
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') {
+          flushBeacon();
+        }
+      });
+      window.addEventListener('pagehide', flushBeacon);
+      window.addEventListener('beforeunload', flushBeacon);
+    } catch {
+      // Setup failed; degrade gracefully but keep enabled so in-buffer flushes
+      // via the interval/track path can still attempt to send.
+    }
+  }
+
+  /**
+   * Track an event. Enqueues into the in-memory buffer (flushing when full) and
+   * dual-sends to PostHog. Never throws.
+   */
+  track(name: EventName, props: EventProps = {}): void {
+    if (!this.enabled) {
+      return;
+    }
+    try {
+      const url = this.currentUrl();
+      const { sessionId } = getSession();
+
+      const event: AnalyticsEvent = {
+        name,
+        ts: Date.now(),
+        anonymous_id: getAnonymousId(),
+        session_id: sessionId,
+        url,
+        referrer: this.lastPath,
+        props: this.sanitizeProps(props),
+      };
+
+      this.buffer.push(event);
+      if (this.buffer.length > MAX_BUFFER_SIZE) {
+        // Drop the oldest to bound memory.
+        this.buffer.splice(0, this.buffer.length - MAX_BUFFER_SIZE);
+      }
+
+      // Dual-send to PostHog Cloud.
+      capturePostHog(name, event.props);
+
+      if (this.buffer.length >= FLUSH_BATCH_SIZE) {
+        this.flush();
+      }
+    } catch {
+      // Swallow — analytics must never break the app.
+    }
+  }
+
+  /**
+   * Record a route change so the next event's `referrer` reflects the page the
+   * user navigated from. Call this AFTER emitting the page_view/page_dwell for
+   * the old path.
+   */
+  setReferrer(path: string): void {
+    this.lastPath = path;
+  }
+
+  /**
+   * Strip any non-primitive values from props so the wire payload stays flat
+   * (string | number | boolean), matching the ingestion contract.
+   */
+  private sanitizeProps(props: EventProps): EventProps {
+    const out: EventProps = {};
+    try {
+      Object.keys(props).forEach((key) => {
+        const value = props[key];
+        if (
+          value === null ||
+          value === undefined ||
+          typeof value === 'string' ||
+          typeof value === 'number' ||
+          typeof value === 'boolean'
+        ) {
+          out[key] = value;
+        } else {
+          // Coerce anything unexpected to a string rather than dropping it.
+          out[key] = String(value);
+        }
+      });
+    } catch {
+      // ignore — return whatever we accumulated
+    }
+    return out;
+  }
+
+  /**
+   * Flush buffered events to the ingestion endpoint. When `useBeacon` is true
+   * (page hide / unload), uses navigator.sendBeacon which is non-blocking and
+   * survives navigation; otherwise uses a keepalive fetch. Fire-and-forget.
+   */
+  flush(useBeacon = false): void {
+    if (!this.enabled || this.buffer.length === 0) {
+      return;
+    }
+
+    // Take ownership of the current batch up front so concurrent track() calls
+    // accumulate into a fresh buffer.
+    const events = this.buffer;
+    this.buffer = [];
+
+    const body: IngestBody = { events };
+    const url = ingestUrl();
+
+    try {
+      const payload = JSON.stringify(body);
+
+      if (useBeacon && typeof navigator.sendBeacon === 'function') {
+        const blob = new Blob([payload], { type: 'application/json' });
+        const ok = navigator.sendBeacon(url, blob);
+        if (!ok) {
+          // Beacon was rejected (e.g. payload too large) — re-queue for a
+          // later normal flush rather than losing the events.
+          this.buffer = events.concat(this.buffer);
+        }
+        return;
+      }
+
+      // Normal path: keepalive fetch so it can complete even if the page is
+      // navigating. Backend responds 202; we ignore the body.
+      void fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload,
+        keepalive: true,
+      }).catch(() => {
+        // Network failure: re-queue so the next flush retries.
+        this.buffer = events.concat(this.buffer);
+        if (this.buffer.length > MAX_BUFFER_SIZE) {
+          this.buffer.splice(0, this.buffer.length - MAX_BUFFER_SIZE);
+        }
+      });
+    } catch {
+      // Serialization/transport failed — re-queue and move on.
+      this.buffer = events.concat(this.buffer);
+    }
+  }
+}
+
+/** Singleton analytics client used throughout the app. */
+export const analytics = new AnalyticsClient();
+
+/** Convenience: initialize the client once (called from App). */
+export const initAnalytics = (): void => analytics.init();
+
+/** Convenience: track an event. */
+export const track = (name: EventName, props?: EventProps): void =>
+  analytics.track(name, props);

--- a/src/lib/analytics/ids.ts
+++ b/src/lib/analytics/ids.ts
@@ -1,0 +1,169 @@
+/**
+ * Identity management for analytics.
+ *
+ * - `anonymous_id`: a uuid v4 persisted in localStorage. Stable across sessions
+ *   and tabs for the same browser, used to stitch a visitor's events together.
+ * - `session_id`: a uuid v4 stored in sessionStorage. A "session" ends after
+ *   ~30 minutes of inactivity, after which a fresh id is minted on the next
+ *   tracked interaction.
+ *
+ * Everything here is defensively wrapped: Storage access can throw (private
+ * mode, disabled cookies, sandboxed iframes), so each accessor falls back to an
+ * in-memory value rather than letting analytics break the app.
+ */
+
+const ANON_ID_KEY = 'uwflow_analytics_anonymous_id';
+const SESSION_ID_KEY = 'uwflow_analytics_session_id';
+const SESSION_LAST_SEEN_KEY = 'uwflow_analytics_session_last_seen';
+
+/** ~30 minutes of idle time ends a session. */
+const SESSION_IDLE_MS = 30 * 60 * 1000;
+
+// In-memory fallbacks used when Web Storage is unavailable or throws.
+let memoryAnonId: string | null = null;
+let memorySessionId: string | null = null;
+let memorySessionLastSeen = 0;
+
+/**
+ * Generate a RFC4122 v4 uuid. Prefers crypto.randomUUID / getRandomValues when
+ * available, falling back to Math.random so this never throws in old browsers.
+ */
+export const uuidv4 = (): string => {
+  try {
+    const cryptoObj: Crypto | undefined =
+      typeof crypto !== 'undefined' ? crypto : undefined;
+
+    if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+      return cryptoObj.randomUUID();
+    }
+
+    if (cryptoObj && typeof cryptoObj.getRandomValues === 'function') {
+      const bytes = new Uint8Array(16);
+      cryptoObj.getRandomValues(bytes);
+      // Per RFC4122 §4.4: set version (4) and variant bits.
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const hex: string[] = [];
+      for (let i = 0; i < 256; i += 1) {
+        hex.push((i + 0x100).toString(16).slice(1));
+      }
+      const b = bytes;
+      const tail =
+        `${hex[b[10]]}${hex[b[11]]}${hex[b[12]]}` +
+        `${hex[b[13]]}${hex[b[14]]}${hex[b[15]]}`;
+      return (
+        `${hex[b[0]]}${hex[b[1]]}${hex[b[2]]}${hex[b[3]]}-` +
+        `${hex[b[4]]}${hex[b[5]]}-` +
+        `${hex[b[6]]}${hex[b[7]]}-` +
+        `${hex[b[8]]}${hex[b[9]]}-` +
+        tail
+      );
+    }
+  } catch {
+    // fall through to Math.random implementation
+  }
+
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+};
+
+const safeLocalGet = (key: string): string | null => {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+const safeLocalSet = (key: string, value: string): void => {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // ignore — storage unavailable
+  }
+};
+
+const safeSessionGet = (key: string): string | null => {
+  try {
+    return window.sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+const safeSessionSet = (key: string, value: string): void => {
+  try {
+    window.sessionStorage.setItem(key, value);
+  } catch {
+    // ignore — storage unavailable
+  }
+};
+
+/** Get (creating + persisting on first call) the stable anonymous visitor id. */
+export const getAnonymousId = (): string => {
+  if (memoryAnonId) {
+    return memoryAnonId;
+  }
+
+  let id = safeLocalGet(ANON_ID_KEY);
+  if (!id) {
+    id = uuidv4();
+    safeLocalSet(ANON_ID_KEY, id);
+  }
+  memoryAnonId = id;
+  return id;
+};
+
+const readSessionLastSeen = (): number => {
+  const raw = safeSessionGet(SESSION_LAST_SEEN_KEY);
+  if (raw) {
+    const parsed = parseInt(raw, 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return memorySessionLastSeen;
+};
+
+const startNewSession = (now: number): string => {
+  const id = uuidv4();
+  memorySessionId = id;
+  memorySessionLastSeen = now;
+  safeSessionSet(SESSION_ID_KEY, id);
+  safeSessionSet(SESSION_LAST_SEEN_KEY, String(now));
+  return id;
+};
+
+/**
+ * Result of resolving the current session id. `isNew` is true when a brand new
+ * session was just started (first ever, or after idle expiry) — callers use
+ * this to emit `session_start` exactly once per session.
+ */
+export type SessionResult = {
+  sessionId: string;
+  isNew: boolean;
+};
+
+/**
+ * Resolve the current session id, rotating it if the previous one has gone idle
+ * for longer than SESSION_IDLE_MS. Also refreshes the "last seen" timestamp so
+ * activity keeps the session alive.
+ */
+export const getSession = (): SessionResult => {
+  const now = Date.now();
+  const existing = safeSessionGet(SESSION_ID_KEY) || memorySessionId;
+  const lastSeen = readSessionLastSeen();
+
+  if (!existing || now - lastSeen > SESSION_IDLE_MS) {
+    return { sessionId: startNewSession(now), isNew: true };
+  }
+
+  // Touch the session so continued activity defers expiry.
+  memorySessionId = existing;
+  memorySessionLastSeen = now;
+  safeSessionSet(SESSION_LAST_SEEN_KEY, String(now));
+  return { sessionId: existing, isNew: false };
+};

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Public analytics API.
+ *
+ * Usage:
+ *   import { initAnalytics, track } from 'lib/analytics';
+ *   initAnalytics();                       // once, near app root
+ *   track('course_view', { course_code }); // anywhere
+ *
+ * Route-level events (session_start / page_view / page_dwell) are wired by the
+ * `usePageTracking` hook mounted near the router.
+ *
+ * See docs/analytics.md for the event taxonomy, the ingestion contract, and the
+ * environment variables (PostHog key/host) a deployer must set.
+ */
+
+export { analytics, initAnalytics, track } from './client';
+export { usePageTracking } from './usePageTracking';
+export { getAnonymousId } from './ids';
+export type { AnalyticsEvent, EventName, EventProps, PropValue } from './types';

--- a/src/lib/analytics/posthog.ts
+++ b/src/lib/analytics/posthog.ts
@@ -1,0 +1,115 @@
+/**
+ * PostHog Cloud dual-send.
+ *
+ * PostHog is our product-analytics surface (dashboards / funnels / retention).
+ * It is loaded lazily on the first tracked event so it has zero cost on routes
+ * where nothing is ever tracked, and it no-ops cleanly when no project key is
+ * configured (e.g. local dev) so the app behaves identically with or without it.
+ *
+ * Configuration (build-time, inlined by CRA's DefinePlugin):
+ *   REACT_APP_POSTHOG_KEY  — public PostHog project API key (safe in client JS)
+ *   REACT_APP_POSTHOG_HOST — PostHog ingestion host (defaults to US cloud)
+ */
+
+import type { PostHog } from 'posthog-js';
+
+import type { EventName, EventProps } from './types';
+
+const POSTHOG_KEY = process.env.REACT_APP_POSTHOG_KEY;
+const POSTHOG_HOST =
+  process.env.REACT_APP_POSTHOG_HOST || 'https://us.i.posthog.com';
+
+let instance: PostHog | null = null;
+let loadPromise: Promise<PostHog | null> | null = null;
+/** Anonymous id to identify once PostHog finishes loading. */
+let pendingIdentity: string | null = null;
+
+/** Whether a PostHog key is configured at all. */
+export const isPostHogEnabled = (): boolean => Boolean(POSTHOG_KEY);
+
+/**
+ * Kick off the (one-time) lazy import + init of posthog-js. Returns the live
+ * instance once ready, or null if PostHog is disabled / failed to load. Safe to
+ * call repeatedly — the import only happens once.
+ */
+const ensurePostHog = (): Promise<PostHog | null> => {
+  if (!POSTHOG_KEY) {
+    return Promise.resolve(null);
+  }
+  if (instance) {
+    return Promise.resolve(instance);
+  }
+  if (loadPromise) {
+    return loadPromise;
+  }
+
+  loadPromise = import('posthog-js')
+    .then(({ default: posthog }) => {
+      posthog.init(POSTHOG_KEY, {
+        api_host: POSTHOG_HOST,
+        // We drive all capture() calls explicitly from track(); disable the
+        // library's own autocapture/pageview so the two stores stay aligned.
+        autocapture: false,
+        capture_pageview: false,
+        capture_pageleave: true,
+        // We manage the anonymous id ourselves; respect DNT at the lib level too.
+        respect_dnt: true,
+        persistence: 'localStorage',
+      });
+      instance = posthog;
+      if (pendingIdentity) {
+        try {
+          posthog.identify(pendingIdentity);
+        } catch {
+          // ignore
+        }
+        pendingIdentity = null;
+      }
+      return posthog;
+    })
+    .catch(() => {
+      // Network/script failure must never surface to the app.
+      return null;
+    });
+
+  return loadPromise;
+};
+
+/**
+ * Associate subsequent PostHog events with our anonymous_id so PostHog's person
+ * profiles line up with our raw store. If PostHog hasn't loaded yet, the id is
+ * applied as soon as it does.
+ */
+export const identifyPostHog = (anonymousId: string): void => {
+  if (!POSTHOG_KEY) {
+    return;
+  }
+  if (instance) {
+    try {
+      instance.identify(anonymousId);
+    } catch {
+      // ignore
+    }
+    return;
+  }
+  pendingIdentity = anonymousId;
+  // Trigger the lazy load so identity is applied promptly.
+  void ensurePostHog();
+};
+
+/** Forward a tracked event to PostHog Cloud. Never throws. */
+export const capturePostHog = (name: EventName, props: EventProps): void => {
+  if (!POSTHOG_KEY) {
+    return;
+  }
+  void ensurePostHog().then((ph) => {
+    if (!ph) {
+      return;
+    }
+    try {
+      ph.capture(name, props);
+    } catch {
+      // ignore
+    }
+  });
+};

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Analytics event taxonomy (v1).
+ *
+ * Event names are snake_case and <= 64 chars, matching the backend ingestion
+ * contract (POST /events). `props` is always a flat object of primitive values
+ * (string | number | boolean) — never nested objects/arrays — so it maps cleanly
+ * onto ClickHouse columns and PostHog properties.
+ */
+
+/** Flat value type allowed inside an event's `props`. */
+export type PropValue = string | number | boolean | null | undefined;
+
+/** Flat props bag. Nested objects/arrays are intentionally disallowed. */
+export type EventProps = Record<string, PropValue>;
+
+/**
+ * The v1 event taxonomy. Adding a new tracked event means adding it here so the
+ * `track()` call site is type-checked against the known set of names.
+ */
+export type EventName =
+  | 'session_start'
+  | 'page_view'
+  | 'page_dwell'
+  | 'course_view'
+  | 'course_search'
+  | 'review_view'
+  | 'profile_view';
+
+/**
+ * The wire shape of a single event in the `events` array of the POST body.
+ * Mirrors the backend ingestion contract exactly.
+ */
+export type AnalyticsEvent = {
+  name: EventName;
+  /** epoch millis (Date.now()) */
+  ts: number;
+  /** uuid v4 persisted in localStorage */
+  anonymous_id: string;
+  /** uuid v4 in sessionStorage, regenerated after ~30 min idle */
+  session_id: string;
+  /** current path (location.pathname + search) */
+  url: string;
+  /** previous path / document.referrer */
+  referrer: string;
+  /** flat object of string/number/bool */
+  props: EventProps;
+};
+
+/** The POST /events request body. */
+export type IngestBody = {
+  events: AnalyticsEvent[];
+};

--- a/src/lib/analytics/usePageTracking.ts
+++ b/src/lib/analytics/usePageTracking.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { analytics, track } from './client';
+
+/**
+ * Mount-once hook (placed near the router) that drives the route-level event
+ * taxonomy:
+ *
+ *   - `session_start` — emitted exactly once per browser session.
+ *   - `page_view`     — on every route change, with the destination path.
+ *   - `page_dwell`    — time spent on a page, emitted when navigating AWAY from
+ *                       it and on tab hide / unload. `props.dwell_ms` is the
+ *                       client-measured residence time; the backend averages
+ *                       these to get "average retention time".
+ *
+ * react-router v5: `useLocation()` gives us a new location object on every
+ * navigation, so the effect below fires per route change.
+ */
+export const usePageTracking = (): void => {
+  const location = useLocation();
+  const path = location.pathname + location.search;
+
+  // Path currently being dwelled on, and when that dwell started.
+  const dwellPathRef = useRef<string | null>(null);
+  const dwellStartRef = useRef<number>(Date.now());
+  // Guard so session_start fires only once for this mounted tracker.
+  const startedRef = useRef(false);
+
+  // session_start: once per session, on first mount of the tracker.
+  useEffect(() => {
+    if (startedRef.current) {
+      return;
+    }
+    startedRef.current = true;
+    track('session_start');
+  }, []);
+
+  // page_view + page_dwell on route change.
+  useEffect(() => {
+    const now = Date.now();
+
+    // Emit dwell for the page we are leaving (if any).
+    const prevPath = dwellPathRef.current;
+    if (prevPath !== null && prevPath !== path) {
+      const dwellMs = now - dwellStartRef.current;
+      track('page_dwell', { path: prevPath, dwell_ms: dwellMs });
+      // The page we just left is now the referrer for subsequent events.
+      analytics.setReferrer(prevPath);
+    }
+
+    // Emit the page_view for the new path.
+    track('page_view', { path });
+
+    // Reset dwell tracking for the new page.
+    dwellPathRef.current = path;
+    dwellStartRef.current = now;
+  }, [path]);
+
+  // Flush a dwell on tab hide / unload so partial dwells aren't lost. We do NOT
+  // reset dwellStartRef here, so if the tab becomes visible again the dwell
+  // continues to accumulate from the original mount time (a subsequent
+  // navigation will then report the full residence time).
+  useEffect(() => {
+    const emitDwell = () => {
+      const current = dwellPathRef.current;
+      if (current === null) {
+        return;
+      }
+      const dwellMs = Date.now() - dwellStartRef.current;
+      track('page_dwell', { path: current, dwell_ms: dwellMs });
+    };
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        emitDwell();
+      }
+    };
+
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('pagehide', emitDwell);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('pagehide', emitDwell);
+    };
+  }, []);
+};

--- a/src/pages/coursePage/CoursePage.tsx
+++ b/src/pages/coursePage/CoursePage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { useSelector } from 'react-redux';
 import { useRouteMatch } from 'react-router-dom';
@@ -26,6 +26,7 @@ import {
   GET_COURSE_WITH_USER_DATA,
 } from 'graphql/queries/course/Course';
 import useModal from 'hooks/useModal';
+import { track } from 'lib/analytics';
 import NotFoundPage from 'pages/notFoundPage/NotFoundPage';
 import { getUserId } from 'utils/Auth';
 import { formatCourseCode } from 'utils/Misc';
@@ -174,6 +175,12 @@ const CoursePage = () => {
   const isLoggedIn = useSelector((state: RootState) => state.auth.loggedIn);
 
   const courseCode = match.params.courseCode.toLowerCase();
+
+  // Emit course_view once per viewed course code.
+  useEffect(() => {
+    track('course_view', { course_code: courseCode });
+  }, [courseCode]);
+
   const query = isLoggedIn ? GET_COURSE_WITH_USER_DATA : GET_COURSE;
   const variables = {
     code: courseCode,

--- a/src/pages/coursePage/CourseReviews.tsx
+++ b/src/pages/coursePage/CourseReviews.tsx
@@ -25,6 +25,7 @@ import {
   COURSE_REVIEWS_WITH_USER_DATA,
 } from 'graphql/queries/course/CourseReview';
 import useCourseReviews, { UPDATE_REVIEW_DATA } from 'hooks/useCourseReviews';
+import { track } from 'lib/analytics';
 import { processRating } from 'utils/Misc';
 import { sortByLiked, sortByReviews, sortReviews } from 'utils/Review';
 
@@ -278,6 +279,17 @@ const CourseReviews = ({ courseId, profsTeaching }: CourseReviewsProps) => {
     }
     // eslint-disable-next-line
   }, [data]);
+
+  // Emit review_view once the reviews for a course have loaded.
+  useEffect(() => {
+    if (!loading) {
+      track('review_view', {
+        course_id: courseId,
+        review_count: reviewDataState.courseReviews.length,
+      });
+    }
+    // eslint-disable-next-line
+  }, [courseId, loading]);
 
   if (loading) {
     return (

--- a/src/pages/explorePage/ExplorePage.tsx
+++ b/src/pages/explorePage/ExplorePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useLocation } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
@@ -17,6 +17,7 @@ import {
   EXPLORE_ALL_QUERY,
   EXPLORE_QUERY,
 } from 'graphql/queries/explore/Explore';
+import { track } from 'lib/analytics';
 import { SearchFilterState } from 'types/Common';
 
 import { EXPLORE_PAGE_ROUTE } from '../../Routes';
@@ -266,6 +267,42 @@ const ExplorePage = () => {
     notifyOnNetworkStatusChange: true,
     fetchPolicy: !query || query === '' ? 'no-cache' : 'cache-and-network',
   });
+
+  // Debounced course_search analytics. A user typing in the SearchBar pushes a
+  // fresh /explore?q=... on each keystroke; debouncing collapses that burst into
+  // a single tracked search once the query settles. Only fires for non-empty
+  // queries (the empty "explore all" view is a page_view, not a search).
+  const trackSearch = useMemo(
+    () =>
+      debounce((searchQuery: string, count: number, isCodeSearch: boolean) => {
+        track('course_search', {
+          query: searchQuery,
+          results_count: count,
+          code_search: isCodeSearch,
+        });
+      }, 500),
+    [],
+  );
+  useEffect(() => () => trackSearch.cancel(), [trackSearch]);
+
+  // Avoid re-emitting for the same query+result-count while Apollo flips
+  // through cache-and-network states.
+  const lastSearchKey = useRef<string>('');
+  useEffect(() => {
+    if (query === '' || loading || !data) {
+      return;
+    }
+    const exploreData = data as ExploreQuery;
+    const resultsCount =
+      (exploreData.search_courses?.length ?? 0) +
+      (exploreData.search_profs?.length ?? 0);
+    const key = `${query}|${codeSearch}|${resultsCount}`;
+    if (key === lastSearchKey.current) {
+      return;
+    }
+    lastSearchKey.current = key;
+    trackSearch(query, resultsCount, codeSearch);
+  }, [query, codeSearch, data, loading, trackSearch]);
 
   return (
     <ExplorePageWrapper>

--- a/src/pages/profPage/ProfPage.tsx
+++ b/src/pages/profPage/ProfPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { useRouteMatch } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
@@ -14,6 +14,7 @@ import {
 import LoadingSpinner from 'components/display/LoadingSpinner';
 import { DEFAULT_ERROR, NOT_FOUND } from 'constants/Messages';
 import { GET_PROF } from 'graphql/queries/prof/Prof';
+import { track } from 'lib/analytics';
 import NotFoundPage from 'pages/notFoundPage/NotFoundPage';
 import ProfInfoHeader from 'pages/profPage/ProfInfoHeader';
 import ProfReviews from 'pages/profPage/ProfReviews';
@@ -77,6 +78,12 @@ export const ProfPage = () => {
   const match = useRouteMatch<{ profCode: string }>();
 
   const profCode = match.params.profCode.toLowerCase();
+
+  // Emit profile_view once per viewed professor profile.
+  useEffect(() => {
+    track('profile_view', { prof_code: profCode });
+  }, [profCode]);
+
   const { loading, error, data } = useQuery<
     GetProfQuery,
     GetProfQueryVariables


### PR DESCRIPTION
## What

Frontend product-analytics tracking. Every event is dual-sent to (a) our own ingestion endpoint `POST /events` (raw store in ClickHouse + S3 archival — see the paired `feat/events-analytics` PR on `uwflow`) and (b) **PostHog Cloud** via `posthog-js` for dashboards / funnels / retention.

## Changes
- **Analytics client** `src/lib/analytics/`:
  - `ids.ts` — `anonymous_id` (localStorage) + `session_id` (sessionStorage, 30-min idle reset), crypto uuid v4.
  - `client.ts` — in-memory buffer + batched flush (interval / size), `keepalive` fetch normally and `navigator.sendBeacon` on tab-hide/unload; DNT guard; fully exception-isolated so it can never throw into React.
  - `posthog.ts` — lazy-init dual-send, no-ops cleanly when no key (dev).
  - `usePageTracking.ts` — route hook emitting `session_start` / `page_view` / `page_dwell`.
  - `types.ts` — typed event names + flat props, matching the backend wire contract exactly.
- **Instrumented events**: `session_start`, `page_view`, `page_dwell` (`dwell_ms` → "average retention time" server-side), `course_view` (`course_code`), `course_search` (`query`, `results_count`, debounced), `review_view`, `profile_view`.
- Wiring in `App.tsx`; `posthog-js@^1.387.0`; docs in `docs/analytics.md`.

## Ingestion target
`POST ${BACKEND_ENDPOINT}/events` — reuses the existing `BACKEND_ENDPOINT` constant (no hardcoded domain): dev → `http://localhost:8081/events`; prod → `/api/events` (same-origin, rewritten to the backend via `vercel.json`).

## Env (all optional; PostHog no-ops when unset)
`REACT_APP_POSTHOG_KEY`, `REACT_APP_POSTHOG_HOST` (default `https://us.i.posthog.com`).

## Verification
`bun run lint-nofix` clean (exit 0); `tsc --noEmit` zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)