### PR TITLE
feat(analytics): auth & account lifecycle events

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -66,6 +66,13 @@ ids, codes, and booleans.
 | `course_search` | Debounced explore search settles       | `query`, `results_count`, `code_search`  | `pages/explorePage/ExplorePage.tsx` |
 | `review_view`   | Course reviews load                    | `course_id`, `review_count`              | `pages/coursePage/CourseReviews.tsx` |
 | `profile_view`  | Professor profile page mounts          | `prof_code`                              | `pages/profPage/ProfPage.tsx` |
+| `login`         | Existing user authenticates            | `method` (`email`/`google`/`facebook`)   | `components/auth/AuthForm.tsx` |
+| `signup`        | New user account is created            | `method` (`email`/`google`/`facebook`)   | `components/auth/AuthForm.tsx` |
+| `auth_failed`   | Login/signup request fails (non-2xx)   | `method`, `mode` (`login`/`signup`), `reason` (error code) | `components/auth/AuthForm.tsx`, `components/auth/SocialLoginContent.tsx` |
+| `logout`        | User clicks "Log out" in the profile dropdown | —                                 | `components/navigation/ProfileDropdown.tsx` |
+| `password_reset_requested` | Reset-code email is successfully sent | —                            | `components/auth/ResetPasswordModalContent.tsx` |
+| `password_reset_completed` | Password is successfully reset      | —                              | `components/auth/ResetPasswordModalContent.tsx` |
+| `account_deleted` | Account is successfully deleted      | —                                        | `components/delete/DeleteAccountModalContent.tsx` |
 
 ## Environment variables
 

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -12,6 +12,7 @@ import { AUTH_ERRORS, AUTH_SUCCESS, DEFAULT_ERROR } from 'constants/Messages';
 import { RESET_PASSWORD_MODAL } from 'constants/Modal';
 import { LOGGED_IN } from 'data/actions/AuthActions';
 import useModal from 'hooks/useModal';
+import { track } from 'lib/analytics';
 import { AuthResponse, ErrorResponse } from 'types/Api';
 import { makePOSTRequest } from 'utils/Api';
 
@@ -58,13 +59,18 @@ const AuthForm = ({
     localStorage.setItem('user_id', response.user_id);
   };
 
-  const onAuthSuccess = (response: AuthResponse) => {
+  const onAuthSuccess = (
+    response: AuthResponse,
+    method: 'email' | 'google' | 'facebook' = 'email',
+  ) => {
     setJWT(response);
     dispatch({ type: LOGGED_IN });
     if (response.is_new) {
+      track('signup', { method });
       toast(AUTH_SUCCESS.signup);
       onSignupComplete();
     } else {
+      track('login', { method });
       toast(AUTH_SUCCESS.login);
       onLoginComplete();
     }
@@ -90,9 +96,14 @@ const AuthForm = ({
 
     if (status >= 400) {
       const errorRes = response as ErrorResponse;
+      track('auth_failed', {
+        method: 'email',
+        mode: endpoint.includes('register') ? 'signup' : 'login',
+        reason: errorRes.error || 'unknown',
+      });
       setErrorMessage(AUTH_ERRORS[errorRes.error] || DEFAULT_ERROR);
     } else {
-      onAuthSuccess(response as AuthResponse);
+      onAuthSuccess(response as AuthResponse, 'email');
     }
   };
 

--- a/src/components/auth/ResetPasswordModalContent.tsx
+++ b/src/components/auth/ResetPasswordModalContent.tsx
@@ -20,6 +20,7 @@ import {
   PASSWORD_RESET_SUCCESS,
   RESET_PASSWORD_ERRORS,
 } from 'constants/Messages';
+import { track } from 'lib/analytics';
 import {
   ErrorResponse,
   ResetPasswordCodeBody,
@@ -265,6 +266,7 @@ const ResetPasswordModalContent = ({
       const errorRes = response as ErrorResponse;
       setErrorMessage(RESET_PASSWORD_ERRORS[errorRes.error] || DEFAULT_ERROR);
     } else {
+      track('password_reset_requested');
       toast(PASSWORD_RESET_SUCCESS.emailSent);
       if (showingForm !== ENTER_RESET_CODE_FORM) {
         setSuccessMessage('');
@@ -339,6 +341,7 @@ const ResetPasswordModalContent = ({
       const errorRes = response as ErrorResponse;
       setErrorMessage(RESET_PASSWORD_ERRORS[errorRes.error] || DEFAULT_ERROR);
     } else {
+      track('password_reset_completed');
       setSuccessMessage('');
       toast(PASSWORD_RESET_SUCCESS.reset);
       handleClose();

--- a/src/components/auth/SocialLoginContent.tsx
+++ b/src/components/auth/SocialLoginContent.tsx
@@ -15,6 +15,7 @@ import {
   GOOGLE_AUTH_ENDPOINT,
 } from 'constants/Api';
 import { AUTH_ERRORS } from 'constants/Messages';
+import { track } from 'lib/analytics';
 import { AuthResponse, ErrorResponse, FbAuthResponse } from 'types/Api';
 import { makePOSTRequest } from 'utils/Api';
 
@@ -28,7 +29,10 @@ import {
 } from './styles/AuthForm';
 
 type SocialLoginContentProps = {
-  onAuthSuccess: (res: AuthResponse) => void;
+  onAuthSuccess: (
+    res: AuthResponse,
+    method?: 'email' | 'google' | 'facebook',
+  ) => void;
 };
 
 const SocialLoginContent = ({ onAuthSuccess }: SocialLoginContentProps) => {
@@ -51,9 +55,14 @@ const SocialLoginContent = ({ onAuthSuccess }: SocialLoginContentProps) => {
 
     if (status >= 400) {
       const errorRes = response as ErrorResponse;
+      track('auth_failed', {
+        method: 'facebook',
+        mode: 'login',
+        reason: errorRes.error || 'unknown',
+      });
       setError(AUTH_ERRORS[errorRes.error] || AUTH_ERRORS.no_facebook_email);
     } else {
-      onAuthSuccess(response as AuthResponse);
+      onAuthSuccess(response as AuthResponse, 'facebook');
     }
   };
 
@@ -72,9 +81,14 @@ const SocialLoginContent = ({ onAuthSuccess }: SocialLoginContentProps) => {
     setGoogleLoading(false);
     if (status >= 400) {
       const errorRes = response as ErrorResponse;
+      track('auth_failed', {
+        method: 'google',
+        mode: 'login',
+        reason: errorRes.error || 'unknown',
+      });
       setError(AUTH_ERRORS[errorRes.error] || AUTH_ERRORS.no_google_email);
     } else {
-      onAuthSuccess(response as AuthResponse);
+      onAuthSuccess(response as AuthResponse, 'google');
     }
   };
 

--- a/src/components/delete/DeleteAccountModalContent.tsx
+++ b/src/components/delete/DeleteAccountModalContent.tsx
@@ -8,6 +8,7 @@ import { useTheme } from 'styled-components';
 import Button from 'components/input/Button';
 import { BACKEND_ENDPOINT, USER_ACCOUNT_ENDPOINT } from 'constants/Api';
 import { DEFAULT_ERROR, DELETE_ACCOUNT_SUCCESS } from 'constants/Messages';
+import { track } from 'lib/analytics';
 import { makeAuthenticatedDELETERequest } from 'utils/Api';
 import { logOut } from 'utils/Auth';
 
@@ -38,6 +39,7 @@ const DeleteAccountModalContent = ({
         {},
       );
       if (status < 400) {
+        track('account_deleted');
         toast(DELETE_ACCOUNT_SUCCESS);
         logOut(dispatch);
         history.push(LANDING_PAGE_ROUTE);

--- a/src/components/navigation/ProfileDropdown.tsx
+++ b/src/components/navigation/ProfileDropdown.tsx
@@ -12,6 +12,7 @@ import { AUTH_MODAL } from 'constants/Modal';
 import { RootState } from 'data/reducers/RootReducer';
 import { GET_USER } from 'graphql/queries/user/User';
 import useModal from 'hooks/useModal';
+import { track } from 'lib/analytics';
 import { logOut } from 'utils/Auth';
 import { getKittenFromID } from 'utils/Kitten';
 
@@ -87,6 +88,7 @@ const ProfileDropdown = () => {
               if (idx === 0) {
                 handleProfileButtonClick();
               } else {
+                track('logout');
                 logOut(dispatch, true);
               }
             }}

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -25,4 +25,11 @@ export type EventName =
   | 'course_view'
   | 'course_search'
   | 'review_view'
-  | 'profile_view';
+  | 'profile_view'
+  | 'login'
+  | 'signup'
+  | 'logout'
+  | 'auth_failed'
+  | 'password_reset_requested'
+  | 'password_reset_completed'
+  | 'account_deleted';


### PR DESCRIPTION
## Summary

Layer 2 of the analytics effort. Stacks on `feat/events-analytics` (the dual-send `track()` foundation) and instruments auth & account lifecycle interactions. Events are emitted at the success/failure of the underlying network calls so they aren't double-counted per button.

## Events added

| Event | When | Props |
|---|---|---|
| `login` | Existing user authenticates | `method` (email/google/facebook) |
| `signup` | New account created | `method` |
| `auth_failed` | Login/signup request returns non-2xx | `method`, `mode` (login/signup), `reason` (short error code, no PII) |
| `logout` | User clicks "Log out" in the profile dropdown | — |
| `password_reset_requested` | Reset-code email successfully sent | — |
| `password_reset_completed` | Password successfully reset | — |
| `account_deleted` | Account successfully deleted | — |

## Files touched

- `src/lib/analytics/types.ts` — added the 7 names to the `EventName` union.
- `src/components/auth/AuthForm.tsx` — `login`/`signup` in the shared `onAuthSuccess` (method threaded through), `auth_failed` for the email path.
- `src/components/auth/SocialLoginContent.tsx` — `auth_failed` for google/facebook; passes `method` into `onAuthSuccess`.
- `src/components/navigation/ProfileDropdown.tsx` — `logout` on the user-initiated dropdown action.
- `src/components/auth/ResetPasswordModalContent.tsx` — `password_reset_requested` / `password_reset_completed`.
- `src/components/delete/DeleteAccountModalContent.tsx` — `account_deleted`.
- `docs/analytics.md` — taxonomy table rows for the new events.

## Notes

- No PII in props: only `method`, `mode`, and a short backend error code (`reason`) — never emails, names, or passwords.
- Intentionally skipped `auth_modal_opened`: the modal is opened from many disparate call sites (ShortlistStar, LikeCourseToggle, Review, CoursePage, etc.) with no single clean hook, so adding it would be invasive. Forced/automatic logouts (empty-user query in `ProfileDropdown`/`ProfilePage`) are also not tracked as `logout` since they aren't user-initiated.
- `bun run lint-nofix` passes clean; `tsc --noEmit` reports 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)