### PR TITLE
feat(analytics): review & rating engagement events

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -73,6 +73,12 @@ ids, codes, and booleans.
 | `password_reset_requested` | Reset-code email is successfully sent | —                            | `components/auth/ResetPasswordModalContent.tsx` |
 | `password_reset_completed` | Password is successfully reset      | —                              | `components/auth/ResetPasswordModalContent.tsx` |
 | `account_deleted` | Account is successfully deleted      | —                                        | `components/delete/DeleteAccountModalContent.tsx` |
+| `review_create` | A new review is successfully posted    | `entity` (`course`), `course_id`, `prof_id` (when rated) | `components/common/CourseReviewBox.tsx` |
+| `review_edit`   | An existing review is successfully updated | `entity` (`course`), `course_id`, `prof_id` (when rated) | `components/common/CourseReviewBox.tsx` |
+| `review_delete` | A review is successfully deleted       | `entity` (`course`), `course_id`, `prof_id` (when rated) | `components/common/CourseReviewBox.tsx` |
+| `review_upvote` | A review's upvote is toggled (mutation success) | `review_id`, `upvoted` (boolean — `true` adding, `false` removing) | `components/display/Review.tsx` |
+| `course_liked_toggle` | A course like/dislike toggle is saved | `course_id`, `liked` (boolean — `true` when set to liked), `state` (`liked`/`disliked`/`cleared`) | `components/input/LikeCourseToggle.tsx` |
+| `review_sort_change` | A review-list sort dropdown changes  | `entity` (`course`/`prof`), `sort` (`most_recent`/`most_helpful`/`most_reviews`/`most_liked`) | `pages/coursePage/CourseReviews.tsx`, `pages/profPage/ProfReviews.tsx` |
 
 ## Environment variables
 

--- a/src/components/common/CourseReviewBox.tsx
+++ b/src/components/common/CourseReviewBox.tsx
@@ -43,6 +43,7 @@ import {
   COURSE_REVIEWS_WITH_USER_DATA,
 } from 'graphql/queries/course/CourseReview';
 import { REFETCH_USER_REVIEW } from 'graphql/queries/user/User';
+import { track } from 'lib/analytics';
 import { getUserId } from 'utils/Auth';
 import { formatCourseCode } from 'utils/Misc';
 
@@ -315,9 +316,20 @@ const CourseReviewBoxContent = ({
         },
       } as UpsertReviewMutation,
     }).then(() => {
+      const profId = profOptions[selectedProf]?.id ?? undefined;
       if (review) {
+        track('review_edit', {
+          entity: 'course',
+          course_id: course.id,
+          ...(profId != null ? { prof_id: profId } : {}),
+        });
         notifyUpdate();
       } else {
+        track('review_create', {
+          entity: 'course',
+          course_id: course.id,
+          ...(profId != null ? { prof_id: profId } : {}),
+        });
         notifyInsert();
       }
       onCancel();
@@ -331,6 +343,11 @@ const CourseReviewBoxContent = ({
       deleteReview({
         variables: { review_id: review ? review.id : null },
       }).then(() => {
+        track('review_delete', {
+          entity: 'course',
+          course_id: course.id,
+          ...(review.prof_id != null ? { prof_id: review.prof_id } : {}),
+        });
         notifyDelete();
         setDeleteReviewModalOpen(false);
         onCancel();

--- a/src/components/display/Review.tsx
+++ b/src/components/display/Review.tsx
@@ -17,6 +17,7 @@ import {
 import { REFETCH_COURSE_REVIEW_UPVOTE } from 'graphql/queries/course/CourseReview';
 import { REFETCH_PROF_REVIEW_UPVOTE } from 'graphql/queries/prof/ProfReview';
 import useModal from 'hooks/useModal';
+import { track } from 'lib/analytics';
 import { getKittenFromID } from 'utils/Kitten';
 
 import {
@@ -129,10 +130,14 @@ const Review = ({ review, isCourseReview }: ReviewProps) => {
     if (userUpvoted) {
       deleteReviewVote({
         variables: { review_id: review.id, user_id: userId },
+      }).then(() => {
+        track('review_upvote', { review_id: review.id, upvoted: false });
       });
     } else {
       insertReviewVote({
         variables: { review_id: review.id, user_id: userId },
+      }).then(() => {
+        track('review_upvote', { review_id: review.id, upvoted: true });
       });
     }
     setUserUpvoted(!userUpvoted);

--- a/src/components/input/LikeCourseToggle.tsx
+++ b/src/components/input/LikeCourseToggle.tsx
@@ -14,6 +14,7 @@ import {
 import { COURSE_REVIEWS_WITH_USER_DATA } from 'graphql/queries/course/CourseReview';
 import { REFETCH_USER_REVIEW } from 'graphql/queries/user/User';
 import useModal from 'hooks/useModal';
+import { track } from 'lib/analytics';
 import { getUserId } from 'utils/Auth';
 
 import {
@@ -100,6 +101,17 @@ const LikeCourseToggle = ({
           },
         },
       },
+    }).then(() => {
+      track('course_liked_toggle', {
+        course_id: courseId,
+        liked: likedValue === 1,
+        state:
+          likedValue === 1
+            ? 'liked'
+            : likedValue === 0
+            ? 'disliked'
+            : 'cleared',
+      });
     });
   };
 

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -32,4 +32,10 @@ export type EventName =
   | 'auth_failed'
   | 'password_reset_requested'
   | 'password_reset_completed'
-  | 'account_deleted';
+  | 'account_deleted'
+  | 'review_create'
+  | 'review_edit'
+  | 'review_delete'
+  | 'review_upvote'
+  | 'course_liked_toggle'
+  | 'review_sort_change';

--- a/src/pages/coursePage/CourseReviews.tsx
+++ b/src/pages/coursePage/CourseReviews.tsx
@@ -93,7 +93,13 @@ const CourseCourseReviews = ({
               color={theme.primary}
               selectedIndex={courseSort}
               options={['most recent', 'most helpful']}
-              onChange={(value) => setCourseSort(value)}
+              onChange={(value) => {
+                setCourseSort(value);
+                track('review_sort_change', {
+                  entity: 'course',
+                  sort: value === 0 ? 'most_recent' : 'most_helpful',
+                });
+              }}
               zIndex={6}
             />
           </DropdownPanelWrapper>
@@ -190,6 +196,10 @@ const CourseProfReviews = ({
                       onChange={(value) => {
                         curSelectedSort[idx] = value;
                         setSelectedSort(curSelectedSort);
+                        track('review_sort_change', {
+                          entity: 'prof',
+                          sort: value === 0 ? 'most_recent' : 'most_helpful',
+                        });
                       }}
                       zIndex={4}
                     />
@@ -359,7 +369,13 @@ const CourseReviews = ({ courseId, profsTeaching }: CourseReviewsProps) => {
           color={theme.primary}
           selectedIndex={profSort}
           options={['most reviews', 'most liked']}
-          onChange={(value) => setProfSort(value)}
+          onChange={(value) => {
+            setProfSort(value);
+            track('review_sort_change', {
+              entity: 'prof',
+              sort: value === 0 ? 'most_reviews' : 'most_liked',
+            });
+          }}
           zIndex={6}
         />
       </ProfDropdownPanelWrapper>

--- a/src/pages/profPage/ProfReviews.tsx
+++ b/src/pages/profPage/ProfReviews.tsx
@@ -17,6 +17,7 @@ import {
   PROF_REVIEWS_WITH_USER_DATA,
 } from 'graphql/queries/prof/ProfReview';
 import useProfReviews, { UPDATE_REVIEW_DATA } from 'hooks/useProfReviews';
+import { track } from 'lib/analytics';
 import { formatCourseCode, processRating } from 'utils/Misc';
 import { sortByLiked, sortByReviews, sortReviews } from 'utils/Review';
 
@@ -124,7 +125,13 @@ const ProfReviews = ({ profId }: ProfReviewsProps) => {
             color={theme.primary}
             selectedIndex={courseSort}
             options={['most reviews', 'most liked']}
-            onChange={(value) => setCourseSort(value)}
+            onChange={(value) => {
+              setCourseSort(value);
+              track('review_sort_change', {
+                entity: 'prof',
+                sort: value === 0 ? 'most_reviews' : 'most_liked',
+              });
+            }}
             zIndex={6}
           />
         </SortFilterDropdownWrapper>
@@ -169,6 +176,10 @@ const ProfReviews = ({ profId }: ProfReviewsProps) => {
                   onChange={(value) => {
                     curSelectedSort[idx] = value;
                     setSelectedSort(curSelectedSort);
+                    track('review_sort_change', {
+                      entity: 'prof',
+                      sort: value === 0 ? 'most_recent' : 'most_helpful',
+                    });
                   }}
                 />
               </DropdownPanelWrapper>


### PR DESCRIPTION
## Summary

Layer 3 of the analytics instrumentation effort. Adds review & rating engagement events using the existing `track()` dual-send client. **Stacks on `feat/analytics-auth`** (PR targets that branch, not `main`).

All events fire at mutation success (via `.then()`) where a mutation exists, to avoid double-counting optimistic/failed actions. `props` are flat snake_case primitives with ids/booleans only — no PII.

## Events added

| Event | Props | Site |
|---|---|---|
| `review_create` | `entity` (`course`), `course_id`, `prof_id` (when rated) | `CourseReviewBox.tsx` → `handlePost` (insert path) |
| `review_edit` | `entity`, `course_id`, `prof_id` (when rated) | `CourseReviewBox.tsx` → `handlePost` (update path) |
| `review_delete` | `entity`, `course_id`, `prof_id` (when rated) | `CourseReviewBox.tsx` → `handleDelete` |
| `review_upvote` | `review_id`, `upvoted` (bool) | `Review.tsx` → `onClickUpvote` |
| `course_liked_toggle` | `course_id`, `liked` (bool), `state` (`liked`/`disliked`/`cleared`) | `LikeCourseToggle.tsx` → `toggleOnClick` |
| `review_sort_change` | `entity` (`course`/`prof`), `sort` | `CourseReviews.tsx`, `ProfReviews.tsx` sort dropdowns |

## Files changed

- `src/lib/analytics/types.ts` — appended 6 names to the `EventName` union.
- `docs/analytics.md` — added taxonomy rows.
- `src/components/common/CourseReviewBox.tsx` — create/edit/delete.
- `src/components/display/Review.tsx` — upvote toggle (covers both course & prof reviews via `isCourseReview`).
- `src/components/input/LikeCourseToggle.tsx` — like/dislike toggle.
- `src/pages/coursePage/CourseReviews.tsx`, `src/pages/profPage/ProfReviews.tsx` — all review-list sort dropdowns.

## Notes

- `CourseReviewBox` is the single create/edit/delete surface (reused by the profile page and the review modal), so instrumenting it once covers all entry points. Its `entity` is always `course`; `prof_id` is included only when a professor was rated.
- Shortlist (Layer 4) and `review_view` (already in the foundation) intentionally left untouched.

## Verification

- `bun run lint-nofix` exits clean.
- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)