### PR TITLE
feat(swap): prompt Quest import when no classes in displayed terms

### DIFF
--- a/src/pages/swapPage/SwapCalendar.tsx
+++ b/src/pages/swapPage/SwapCalendar.tsx
@@ -111,6 +111,19 @@ const groupScheduleByTerm = (schedule: UserScheduleFragment['schedule']) => {
   return map;
 };
 
+// Whether the schedule has classes in each of the two terms the swap calendar
+// shows (current + next). Drives the default term here and the "Import your
+// schedule from Quest" empty-state prompt in SwapPage.
+export const getDisplayedTermPresence = (
+  schedule: UserScheduleFragment['schedule'],
+) => {
+  const termMap = groupScheduleByTerm(schedule);
+  return {
+    thisHasData: !!termMap[termCodeToDate(getCurrentTermCode())]?.length,
+    nextHasData: !!termMap[termCodeToDate(getNextTermCode())]?.length,
+  };
+};
+
 const timesOverlap = (s1: number, e1: number, s2: number, e2: number) =>
   s1 < e2 && s2 < e1;
 
@@ -248,8 +261,7 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
   const nextTermLabel = termCodeToDate(nextTermCode);
 
   const [selectedTerm, setSelectedTerm] = useState<string>(() => {
-    const thisHasData = !!termMap[thisTermLabel]?.length;
-    const nextHasData = !!termMap[nextTermLabel]?.length;
+    const { thisHasData, nextHasData } = getDisplayedTermPresence(schedule);
     return !nextHasData || thisHasData ? thisTermLabel : nextTermLabel;
   });
   // The clicked calendar block's course + section type (e.g. CS 240 / LEC).

--- a/src/pages/swapPage/SwapPage.tsx
+++ b/src/pages/swapPage/SwapPage.tsx
@@ -14,7 +14,7 @@ import useModal from 'hooks/useModal';
 import { cn } from 'lib/utils';
 
 import DEMO_SCHEDULE from './demoSchedule';
-import SwapCalendar from './SwapCalendar';
+import SwapCalendar, { getDisplayedTermPresence } from './SwapCalendar';
 
 // PageWrapper mixin (min-height accounts for FOOTER_HEIGHT 70px +
 // FOOTER_MARGIN_TOP 32px) on the app's light1 background. The fade-in lives on
@@ -38,13 +38,17 @@ const SwapPage = () => {
 
   const user = isLoggedIn ? data?.user[0] : null;
   const schedule = isLoggedIn ? user?.schedule ?? [] : [];
-  const hasSchedule = schedule.length > 0;
+  // The calendar only shows the current + next term, so prompt for a Quest
+  // import whenever neither of those terms has classes — not merely when the
+  // schedule is empty (e.g. a returning user whose schedule is all past terms).
+  const { thisHasData, nextHasData } = getDisplayedTermPresence(schedule);
+  const hasDisplayedTermClasses = thisHasData || nextHasData;
   // Logged-out visitors see a non-interactive sample schedule behind the
   // login lock card instead of an empty grid.
-  const isDemo = !isLoggedIn && !hasSchedule;
+  const isDemo = !isLoggedIn && !hasDisplayedTermClasses;
 
   useEffect(() => {
-    if (!hasSchedule) {
+    if (!hasDisplayedTermClasses) {
       document.body.style.overflow = 'hidden';
     } else {
       document.body.style.overflow = '';
@@ -52,7 +56,7 @@ const SwapPage = () => {
     return () => {
       document.body.style.overflow = '';
     };
-  }, [hasSchedule]);
+  }, [hasDisplayedTermClasses]);
 
   if (isLoggedIn && (loading || !data)) {
     return (
@@ -69,7 +73,7 @@ const SwapPage = () => {
     <div className={swapPageWrapperClasses}>
       <Helmet>
         <title>Section Swap - UW Flow</title>
-        {hasSchedule && (
+        {hasDisplayedTermClasses && (
           <meta
             name="description"
             content="View your UW schedule and swap course sections."
@@ -84,7 +88,7 @@ const SwapPage = () => {
         <div
           className={cn(
             'fixed inset-0 z-10 box-border flex items-start justify-center overflow-y-auto bg-white/55 backdrop-blur [transition:opacity_0.4s_ease]',
-            !hasSchedule
+            !hasDisplayedTermClasses
               ? 'pointer-events-auto opacity-100'
               : 'pointer-events-none opacity-0',
           )}


### PR DESCRIPTION
## What

The section swap calendar only shows the **current** and **next** term, but the "Import your schedule from Quest" prompt only appeared when the schedule was *entirely* empty. A returning user whose schedule is all past terms saw an empty grid with no way to re-import.

## Changes

- **`SwapCalendar.tsx`** — extract `getDisplayedTermPresence(schedule)` returning `{ thisHasData, nextHasData }` for the two displayed terms (current + next). The existing default-term initializer now reuses it (single source of truth).
- **`SwapPage.tsx`** — the existing `ScheduleUploadModalContent` ("Import your schedule from Quest") prompt now triggers on `!hasDisplayedTermClasses` instead of `schedule.length === 0`.

## Behaviour

- No classes in **either** displayed term → show the Quest import prompt.
- Classes in **one** term → default the calendar to that term (already implemented; now shares the helper).

## Test plan

- [ ] Logged-in user with a current/next-term schedule → calendar shows, defaults to the term with classes, no prompt.
- [ ] Logged-in user whose schedule is only past terms → import prompt appears.
- [ ] New / empty user → import prompt appears.
- [ ] Logged-out user → demo schedule behind login lock (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)