### PR TITLE
feat(swap): track schedule upload attempts in PostHog

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -4,9 +4,10 @@ UW Flow sends product analytics to **PostHog Cloud** and nothing else. PostHog
 is the single destination: it stores the events and powers dashboards, funnels,
 and retention.
 
-We don't emit any custom events. PostHog's automatic pageview/session capture is
-the whole of our analytics — there is no custom ingestion endpoint and no second
-store.
+PostHog's automatic pageview/session capture is the backbone of our analytics —
+there is no custom ingestion endpoint and no second store. On top of that we emit
+a handful of explicit `track()` events for key product actions (e.g.
+`swap_schedule_upload_attempt` when a user submits a schedule on the Swap page).
 
 ## Client architecture
 
@@ -14,9 +15,9 @@ Everything lives under [`src/lib/analytics/`](../src/lib/analytics):
 
 | File         | Responsibility                                               |
 |--------------|--------------------------------------------------------------|
-| `index.ts`   | `initAnalytics()` — initialize PostHog once, near the app root. Never throws. |
+| `index.ts`   | `initAnalytics()` — initialize PostHog once, near the app root. `track(event, props?)` — emit a custom event (no-ops until init'd). Never throws. |
 
-That's the whole library. PostHog itself handles everything we used to hand-roll:
+PostHog itself handles everything we used to hand-roll:
 
 - **Pageviews & sessions** — captured automatically on SPA navigation via
   `capture_pageview: 'history_change'`, plus `$pageleave` on exit. We do **not**

--- a/src/components/upload/ScheduleUploadModalContent.tsx
+++ b/src/components/upload/ScheduleUploadModalContent.tsx
@@ -64,12 +64,16 @@ export type ScheduleUploadModalContentProps = {
   onAfterUploadSuccess?: (data?: ParseOnlyScheduleResponse) => void;
   onSkip?: () => void;
   showSkipStepButton?: boolean;
+  // Fired when the user submits a non-empty schedule (an upload attempt), before
+  // the result is known. Used by callers that want to track the action.
+  onUploadAttempt?: () => void;
 };
 
 const ScheduleUploadModalContent = ({
   showSkipStepButton = false,
   onAfterUploadSuccess = () => {},
   onSkip = () => {},
+  onUploadAttempt = () => {},
 }: ScheduleUploadModalContentProps) => {
   const theme = useTheme();
 
@@ -88,6 +92,7 @@ const ScheduleUploadModalContent = ({
       return;
     }
 
+    onUploadAttempt();
     setUploadState(UPLOAD_PENDING);
     const [response, status] = await makeAuthenticatedPOSTRequest<
       ScheduleParseBody,

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -4,8 +4,8 @@
  *   import { initAnalytics } from 'lib/analytics';
  *   initAnalytics();  // once, near the app root
  *
- * We don't emit any custom events: PostHog captures pageviews/pageleaves and
- * sessions automatically, and that's the whole of our analytics. PostHog also
+ * PostHog captures pageviews/pageleaves and sessions automatically; beyond that
+ * we emit a few explicit `track()` events for key product actions. PostHog also
  * handles identity, batching, delivery on tab-hide/unload, and Do-Not-Track.
  *
  * Configuration (build-time, inlined by CRA's DefinePlugin):
@@ -45,6 +45,25 @@ export const initAnalytics = (): void => {
       respect_dnt: true,
     });
     enabled = true;
+  } catch {
+    // Analytics must never break the app.
+  }
+};
+
+/**
+ * Send a custom PostHog event. No-ops until `initAnalytics()` has run with a
+ * key configured (e.g. local dev), so callers never need to guard.
+ */
+export const track = (
+  event: string,
+  properties?: Record<string, unknown>,
+): void => {
+  if (!enabled) {
+    return;
+  }
+
+  try {
+    posthog.capture(event, properties);
   } catch {
     // Analytics must never break the app.
   }

--- a/src/pages/swapPage/SwapPage.tsx
+++ b/src/pages/swapPage/SwapPage.tsx
@@ -11,6 +11,7 @@ import { AUTH_MODAL, SWAP_TOUR_MODAL } from 'constants/Modal';
 import { RootState } from 'data/reducers/RootReducer';
 import { GET_USER } from 'graphql/queries/user/User';
 import useModal from 'hooks/useModal';
+import { track } from 'lib/analytics';
 import { cn } from 'lib/utils';
 
 import DEMO_SCHEDULE from './demoSchedule';
@@ -117,6 +118,7 @@ const SwapPage = () => {
                 onAfterUploadSuccess={() =>
                   refetch({ id: Number(localStorage.getItem('user_id')) })
                 }
+                onUploadAttempt={() => track('swap_schedule_upload_attempt')}
                 showSkipStepButton={false}
               />
             ) : (


### PR DESCRIPTION
## What

Fires a PostHog `swap_schedule_upload_attempt` event the moment a logged-in user submits a non-empty schedule on `/swap`, before the result is known — so failed/rejected attempts are counted too.

## Changes

- **`lib/analytics/index.ts`** — added a thin `track(event, props?)` wrapper around `posthog.capture` (no-ops until `initAnalytics()` runs, never throws, matching the existing pattern).
- **`ScheduleUploadModalContent.tsx`** — added an optional `onUploadAttempt` callback, called when an upload begins.
- **`SwapPage.tsx`** — passes `onUploadAttempt={() => track('swap_schedule_upload_attempt')}`.
- **`docs/analytics.md`** — updated the now-stale "no custom events" note.

## Notes

Wired via a callback prop rather than firing inside the shared `ScheduleUploadModalContent`, since that component is also used by the welcome/onboarding flow and the generic upload modal — those stay untracked, keeping this swap-page-specific.

`bun run lint-nofix` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)