### PR TITLE
feat(auth): add email verification step to signup

### DIFF
--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -29,6 +29,7 @@ import { AuthFormState, HandleAuthFunction } from './AuthTypes';
 import LoginContent from './LoginContent';
 import SignupContent from './SignupContent';
 import SocialLoginContent from './SocialLoginContent';
+import VerifyEmailContent from './VerifyEmailContent';
 
 type AuthFormProps = {
   onLoginComplete: () => void;
@@ -52,6 +53,9 @@ const AuthForm = ({
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  // Non-empty email puts the form into the "enter verification code" step.
+  const [verifyEmail, setVerifyEmail] = useState('');
+  const [verifySendOnMount, setVerifySendOnMount] = useState(false);
 
   const setJWT = (response: AuthResponse) => {
     localStorage.setItem('token', response.token);
@@ -59,6 +63,14 @@ const AuthForm = ({
   };
 
   const onAuthSuccess = (response: AuthResponse) => {
+    // Email signups return no token: the account exists but isn't verified.
+    // Switch to the verification step instead of logging the user in.
+    if (response.is_new && !response.token) {
+      setVerifySendOnMount(false);
+      setVerifyEmail(email);
+      return;
+    }
+
     setJWT(response);
     dispatch({ type: LOGGED_IN });
     if (response.is_new) {
@@ -68,6 +80,14 @@ const AuthForm = ({
       toast(AUTH_SUCCESS.login);
       onLoginComplete();
     }
+  };
+
+  const onVerified = (response: AuthResponse) => {
+    setVerifyEmail('');
+    setJWT(response);
+    dispatch({ type: LOGGED_IN });
+    toast(AUTH_SUCCESS.signup);
+    onSignupComplete();
   };
 
   const handleAuth: HandleAuthFunction = async <T extends object>(
@@ -90,6 +110,13 @@ const AuthForm = ({
 
     if (status >= 400) {
       const errorRes = response as ErrorResponse;
+      // Logging into an unverified account: jump to the code step and email a
+      // fresh code, rather than showing a dead-end error.
+      if (errorRes.error === 'email_not_verified') {
+        setVerifySendOnMount(true);
+        setVerifyEmail(email);
+        return;
+      }
       setErrorMessage(AUTH_ERRORS[errorRes.error] || DEFAULT_ERROR);
     } else {
       onAuthSuccess(response as AuthResponse);
@@ -108,47 +135,62 @@ const AuthForm = ({
     <>
       <Wrapper margin={margin}>
         <ContentWrapper>
-          {showLoginForm ? (
-            <LoginContent
-              handleAuth={handleAuth}
-              formState={formState}
-              setEmail={setEmail}
-              setPassword={setPassword}
-              onShowResetPassword={() =>
-                openModal(RESET_PASSWORD_MODAL, {
-                  handleClose: () => closeModal(RESET_PASSWORD_MODAL),
-                })
-              }
+          {verifyEmail !== '' ? (
+            <VerifyEmailContent
+              email={verifyEmail}
+              sendOnMount={verifySendOnMount}
+              onVerified={onVerified}
             />
           ) : (
-            <SignupContent
-              handleAuth={handleAuth}
-              formState={formState}
-              setFirstName={setFirstName}
-              setLastName={setLastName}
-              setEmail={setEmail}
-              setPassword={setPassword}
-              setConfirmPassword={setConfirmPassword}
-            />
+            <>
+              {showLoginForm ? (
+                <LoginContent
+                  handleAuth={handleAuth}
+                  formState={formState}
+                  setEmail={setEmail}
+                  setPassword={setPassword}
+                  onShowResetPassword={() =>
+                    openModal(RESET_PASSWORD_MODAL, {
+                      handleClose: () => closeModal(RESET_PASSWORD_MODAL),
+                    })
+                  }
+                />
+              ) : (
+                <SignupContent
+                  handleAuth={handleAuth}
+                  formState={formState}
+                  setFirstName={setFirstName}
+                  setLastName={setLastName}
+                  setEmail={setEmail}
+                  setPassword={setPassword}
+                  setConfirmPassword={setConfirmPassword}
+                />
+              )}
+              <OrWrapper>OR</OrWrapper>
+              <SocialLoginContent onAuthSuccess={onAuthSuccess} />
+              <PrivacyWrapper>
+                <GreyText>Read our </GreyText>
+                <PrivacyPolicyText
+                  to={PRIVACY_PAGE_ROUTE}
+                  onClick={closeAuthModal}
+                >
+                  Privacy Policy
+                </PrivacyPolicyText>
+              </PrivacyWrapper>
+            </>
           )}
-          <OrWrapper>OR</OrWrapper>
-          <SocialLoginContent onAuthSuccess={onAuthSuccess} />
-          <PrivacyWrapper>
-            <GreyText>Read our </GreyText>
-            <PrivacyPolicyText to={PRIVACY_PAGE_ROUTE} onClick={closeAuthModal}>
-              Privacy Policy
-            </PrivacyPolicyText>
-          </PrivacyWrapper>
         </ContentWrapper>
-        <SwapModalWrapper>
-          New to UW Flow?
-          <SwapModalLink
-            onClick={() => setShowLoginForm(!showLoginForm)}
-            onMouseDown={(e) => e.preventDefault()}
-          >
-            {showLoginForm ? 'Sign up' : 'Log in'}
-          </SwapModalLink>
-        </SwapModalWrapper>
+        {verifyEmail === '' && (
+          <SwapModalWrapper>
+            New to UW Flow?
+            <SwapModalLink
+              onClick={() => setShowLoginForm(!showLoginForm)}
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              {showLoginForm ? 'Sign up' : 'Log in'}
+            </SwapModalLink>
+          </SwapModalWrapper>
+        )}
       </Wrapper>
     </>
   );

--- a/src/components/auth/VerifyEmailContent.tsx
+++ b/src/components/auth/VerifyEmailContent.tsx
@@ -1,0 +1,128 @@
+import React, { SyntheticEvent, useCallback, useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+
+import Button from 'components/input/Button';
+import Textbox from 'components/input/Textbox';
+import {
+  BACKEND_ENDPOINT,
+  EMAIL_VERIFY_ENDPOINT,
+  EMAIL_VERIFY_SEND_ENDPOINT,
+} from 'constants/Api';
+import { AUTH_ERRORS, AUTH_SUCCESS, DEFAULT_ERROR } from 'constants/Messages';
+import {
+  AuthResponse,
+  EmailVerifyBody,
+  EmailVerifySendBody,
+  ErrorResponse,
+} from 'types/Api';
+import { makePOSTRequest } from 'utils/Api';
+
+import { Error, Form, Header, TextboxWrapper } from './styles/AuthForm';
+import { GreyLink, Text } from './styles/ResetPasswordModal';
+
+type VerifyEmailContentProps = {
+  email: string;
+  onVerified: (response: AuthResponse) => void;
+  // When reaching this step from a login attempt no code has been sent yet, so
+  // request one on mount. After signup the register call already queued a code.
+  sendOnMount?: boolean;
+};
+
+const VerifyEmailContent = ({
+  email,
+  onVerified,
+  sendOnMount = false,
+}: VerifyEmailContentProps) => {
+  const [code, setCode] = useState('');
+  const [codeError, setCodeError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const sendCode = useCallback(async () => {
+    const [response, status] = await makePOSTRequest<
+      EmailVerifySendBody,
+      ErrorResponse | object
+    >(`${BACKEND_ENDPOINT}${EMAIL_VERIFY_SEND_ENDPOINT}`, { email });
+
+    if (status >= 400) {
+      const errorRes = response as ErrorResponse;
+      setErrorMessage(AUTH_ERRORS[errorRes.error] || DEFAULT_ERROR);
+    } else {
+      toast(AUTH_SUCCESS.verificationSent);
+    }
+  }, [email]);
+
+  useEffect(() => {
+    if (sendOnMount) {
+      sendCode();
+    }
+  }, [sendOnMount, sendCode]);
+
+  const handleResend = async (event: SyntheticEvent<EventTarget>) => {
+    event.preventDefault();
+    setErrorMessage('');
+    await sendCode();
+  };
+
+  const handleSubmit = async (event: SyntheticEvent<EventTarget>) => {
+    event.preventDefault();
+
+    if (code === '') {
+      setCodeError(true);
+      return;
+    }
+
+    setLoading(true);
+    setErrorMessage('');
+    const [response, status] = await makePOSTRequest<
+      EmailVerifyBody,
+      AuthResponse | ErrorResponse
+    >(`${BACKEND_ENDPOINT}${EMAIL_VERIFY_ENDPOINT}`, { key: code });
+    setLoading(false);
+
+    if (status >= 400) {
+      const errorRes = response as ErrorResponse;
+      setErrorMessage(AUTH_ERRORS[errorRes.error] || DEFAULT_ERROR);
+      setCodeError(true);
+    } else {
+      onVerified(response as AuthResponse);
+    }
+  };
+
+  return (
+    <>
+      <Header>Verify your email</Header>
+      <Text>
+        We sent a verification code to {email}. Enter it below to finish setting
+        up your account.
+      </Text>
+      <Form onSubmit={handleSubmit}>
+        {errorMessage !== '' && <Error>{errorMessage}</Error>}
+        <TextboxWrapper>
+          <Textbox
+            options={{ width: '100%', name: 'verification-code' }}
+            placeholder="Verification code"
+            error={codeError}
+            text={code}
+            setText={(value) => {
+              setCode(value);
+              setCodeError(false);
+            }}
+          />
+          <GreyLink onClick={handleResend}>Send me a new code</GreyLink>
+        </TextboxWrapper>
+        <Button
+          loading={loading}
+          margin="0 0 16px 0"
+          width="100%"
+          handleClick={handleSubmit}
+          type="submit"
+        >
+          Verify
+        </Button>
+      </Form>
+    </>
+  );
+};
+
+export default VerifyEmailContent;

--- a/src/constants/Api.tsx
+++ b/src/constants/Api.tsx
@@ -29,6 +29,10 @@ export const GOOGLE_AUTH_ENDPOINT = '/auth/google/login';
 export const FACEBOOK_AUTH_ENDPOINT = '/auth/facebook/login';
 export const AUTH_REFRESH_ENDPOINT = '/auth/refresh';
 
+/* Email verification */
+export const EMAIL_VERIFY_SEND_ENDPOINT = '/auth/email/verify/send';
+export const EMAIL_VERIFY_ENDPOINT = '/auth/email/verify';
+
 /* Reset password */
 export const RESET_PASSWORD_KEY_EMAIL_ENDPOINT =
   '/auth/forgot-password/send-email';

--- a/src/constants/Messages.tsx
+++ b/src/constants/Messages.tsx
@@ -9,6 +9,8 @@ export const AUTH_ERRORS: MessageObject = {
   email_not_registered: 'We don’t recognize that email.',
   email_wrong_password: 'Invalid password.',
   email_taken: 'That email has already been registered.',
+  email_not_verified: 'Please verify your email to continue.',
+  invalid_verify_key: 'That verification code is invalid or has expired.',
   no_facebook_email: 'We were unable able to log you in through Facebook.',
   no_google_email: 'We were unable able to log you in through Google.',
 };
@@ -85,6 +87,7 @@ export const AUTH_SUCCESS: MessageObject = {
   login: 'Logged in!',
   logout: 'Logged out!',
   signup: 'Signed up!',
+  verificationSent: 'Verification code sent!',
 };
 
 export const SUBSCRIPTION_SUCCESS: MessageObject = {

--- a/src/types/Api.tsx
+++ b/src/types/Api.tsx
@@ -33,6 +33,15 @@ export type AuthRefreshResponse = {
   token: string;
 };
 
+/* Email verification */
+export type EmailVerifySendBody = {
+  email: string;
+};
+
+export type EmailVerifyBody = {
+  key: string;
+};
+
 /* Reset password */
 export type ResetPasswordEmailBody = {
   email: string;


### PR DESCRIPTION
## What

Adds the client side of the new signup email-verification flow. After an email signup — or when logging into an account that isn't verified yet — the auth modal shows a code-entry step. The JWT is only stored once the code is verified.

## Changes

- **`VerifyEmailContent.tsx`** (new): code-entry view (mirrors the reset-password code step) with a "Send me a new code" resend link.
- **`AuthForm.tsx`**: email signups now return no token → switch to the verify step instead of logging in. Logging into an unverified account (`email_not_verified`) jumps to the verify step and emails a fresh code. `onVerified` stores the JWT and completes signup.
- API constants/types for `/auth/email/verify` and `/auth/email/verify/send`; messages for `email_not_verified` / `invalid_verify_key`.

Social and already-verified email logins are unchanged.

## Verification

- `bun run lint-nofix` ✅ clean
- `tsc --noEmit` ✅ clean

> Requires the backend PR UWFlow/uwflow#191 (new `/auth/email/verify*` endpoints + `verified` column). Without it, signup will not return the no-token response that triggers the verify step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)