### PR TITLE
feat(analytics): track account_created and review_posted in PostHog

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -14,7 +14,7 @@ Everything lives under [`src/lib/analytics/`](../src/lib/analytics):
 
 | File         | Responsibility                                               |
 |--------------|--------------------------------------------------------------|
-| `index.ts`   | `initAnalytics()` (init once near the app root), `capture(event, props)` (emit a custom event), `identify(userId)` (tie events to a user). All never throw and no-op when no key is configured. |
+| `index.ts`   | `initAnalytics()` (init once near the app root), `capture(event, props)` (emit a custom event), `identify(userId)` (tie events to a user). All never throw, no-op when no key is configured, and `capture`/`identify` fire on the side (deferred a macrotask) so they never block UI. |
 
 PostHog itself handles everything we used to hand-roll:
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -4,9 +4,9 @@ UW Flow sends product analytics to **PostHog Cloud** and nothing else. PostHog
 is the single destination: it stores the events and powers dashboards, funnels,
 and retention.
 
-We don't emit any custom events. PostHog's automatic pageview/session capture is
-the whole of our analytics — there is no custom ingestion endpoint and no second
-store.
+Beyond PostHog's automatic pageview/session capture, we emit a small number of
+custom product events (see [Custom events](#custom-events)). There is no custom
+ingestion endpoint and no second store — everything goes to PostHog.
 
 ## Client architecture
 
@@ -14,16 +14,16 @@ Everything lives under [`src/lib/analytics/`](../src/lib/analytics):
 
 | File         | Responsibility                                               |
 |--------------|--------------------------------------------------------------|
-| `index.ts`   | `initAnalytics()` — initialize PostHog once, near the app root. Never throws. |
+| `index.ts`   | `initAnalytics()` (init once near the app root), `capture(event, props)` (emit a custom event), `identify(userId)` (tie events to a user). All never throw and no-op when no key is configured. |
 
-That's the whole library. PostHog itself handles everything we used to hand-roll:
+PostHog itself handles everything we used to hand-roll:
 
 - **Pageviews & sessions** — captured automatically on SPA navigation via
   `capture_pageview: 'history_change'`, plus `$pageleave` on exit. We do **not**
   emit our own `page_view` or `*_view` events.
 - **Identity & sessions** — PostHog assigns an anonymous `distinct_id` and tracks
-  sessions automatically. (Call `posthog.identify(userId)` later if/when we want
-  to tie events to a logged-in user.)
+  sessions automatically. After login/signup we call `identify(user_id)` so events
+  (and the preceding anonymous session) attach to the user's PostHog person.
 - **Delivery** — PostHog batches events and flushes them, including on tab hide /
   unload, so we don't manage a buffer or `sendBeacon`.
 - **Do-Not-Track** — `respect_dnt: true` makes PostHog a no-op when the browser
@@ -32,12 +32,46 @@ That's the whole library. PostHog itself handles everything we used to hand-roll
 `autocapture` is disabled: we don't want raw DOM clicks in the stream, only
 PostHog's pageview/session signals.
 
+## Custom events
+
+We deliberately keep custom events few. Today there are two:
+
+### `account_created`
+
+Fired once when a brand-new account is created (`is_new` from the auth
+response), from `AuthForm`'s `onAuthSuccess`.
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `method` | `'email' \| 'google' \| 'facebook'` | Which signup path was used. |
+
+### `review_posted`
+
+Fired when a user posts a review. Two shapes share one event so funnels and
+totals stay simple — split on `review_type`.
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `review_type` | `'full' \| 'like'` | `'full'` = the rich review form; `'like'` = the thumbs up/down toggle. |
+| `about_prof` | `boolean` | Whether the review includes a professor. Always `false` for likes. |
+| `course_id` / `course_code` | `number` / `string` | The course reviewed. |
+| `liked` | `0 \| 1` | Thumbs down / up. |
+
+`review_type: 'full'` adds: `is_update` (editing vs first post), `prof_id`,
+`course_useful`, `course_easy`, `prof_clear`, `prof_engaging` (null when no
+prof), `has_course_comment`, `has_prof_comment`, `is_anonymous`.
+
+Toggling a like **off** (clearing it) is a removal, not a post, so it emits no
+event.
+
 ## Usage
 
 ```ts
-import { initAnalytics } from 'lib/analytics';
+import { initAnalytics, capture, identify } from 'lib/analytics';
 
 initAnalytics(); // once, near the app root (App.tsx)
+identify(userId); // after login/signup
+capture('review_posted', { review_type: 'like', liked: 1 /* … */ });
 ```
 
 `initAnalytics()` no-ops until a PostHog key is configured, so local dev without

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -64,15 +64,18 @@ const AuthForm = ({
   const onAuthSuccess = (response: AuthResponse, method: AuthMethod) => {
     setJWT(response);
     dispatch({ type: LOGGED_IN });
-    // Tie this session (and future events) to the user's PostHog person.
-    identify(response.user_id);
     if (response.is_new) {
-      capture('account_created', { method });
       toast(AUTH_SUCCESS.signup);
       onSignupComplete();
     } else {
       toast(AUTH_SUCCESS.login);
       onLoginComplete();
+    }
+    // Analytics on the side — identify/capture defer themselves, so the login
+    // toast and redirect above run first and are never blocked.
+    identify(response.user_id);
+    if (response.is_new) {
+      capture('account_created', { method });
     }
   };
 

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -12,6 +12,7 @@ import { AUTH_ERRORS, AUTH_SUCCESS, DEFAULT_ERROR } from 'constants/Messages';
 import { RESET_PASSWORD_MODAL } from 'constants/Modal';
 import { LOGGED_IN } from 'data/actions/AuthActions';
 import useModal from 'hooks/useModal';
+import { capture, identify } from 'lib/analytics';
 import { AuthResponse, ErrorResponse } from 'types/Api';
 import { makePOSTRequest } from 'utils/Api';
 
@@ -29,6 +30,8 @@ import { AuthFormState, HandleAuthFunction } from './AuthTypes';
 import LoginContent from './LoginContent';
 import SignupContent from './SignupContent';
 import SocialLoginContent from './SocialLoginContent';
+
+export type AuthMethod = 'email' | 'google' | 'facebook';
 
 type AuthFormProps = {
   onLoginComplete: () => void;
@@ -58,10 +61,13 @@ const AuthForm = ({
     localStorage.setItem('user_id', response.user_id);
   };
 
-  const onAuthSuccess = (response: AuthResponse) => {
+  const onAuthSuccess = (response: AuthResponse, method: AuthMethod) => {
     setJWT(response);
     dispatch({ type: LOGGED_IN });
+    // Tie this session (and future events) to the user's PostHog person.
+    identify(response.user_id);
     if (response.is_new) {
+      capture('account_created', { method });
       toast(AUTH_SUCCESS.signup);
       onSignupComplete();
     } else {
@@ -92,7 +98,7 @@ const AuthForm = ({
       const errorRes = response as ErrorResponse;
       setErrorMessage(AUTH_ERRORS[errorRes.error] || DEFAULT_ERROR);
     } else {
-      onAuthSuccess(response as AuthResponse);
+      onAuthSuccess(response as AuthResponse, 'email');
     }
   };
 

--- a/src/components/auth/SocialLoginContent.tsx
+++ b/src/components/auth/SocialLoginContent.tsx
@@ -26,9 +26,10 @@ import {
   GoogleButton,
   GoogleIcon,
 } from './styles/AuthForm';
+import { AuthMethod } from './AuthForm';
 
 type SocialLoginContentProps = {
-  onAuthSuccess: (res: AuthResponse) => void;
+  onAuthSuccess: (res: AuthResponse, method: AuthMethod) => void;
 };
 
 const SocialLoginContent = ({ onAuthSuccess }: SocialLoginContentProps) => {
@@ -53,7 +54,7 @@ const SocialLoginContent = ({ onAuthSuccess }: SocialLoginContentProps) => {
       const errorRes = response as ErrorResponse;
       setError(AUTH_ERRORS[errorRes.error] || AUTH_ERRORS.no_facebook_email);
     } else {
-      onAuthSuccess(response as AuthResponse);
+      onAuthSuccess(response as AuthResponse, 'facebook');
     }
   };
 
@@ -74,7 +75,7 @@ const SocialLoginContent = ({ onAuthSuccess }: SocialLoginContentProps) => {
       const errorRes = response as ErrorResponse;
       setError(AUTH_ERRORS[errorRes.error] || AUTH_ERRORS.no_google_email);
     } else {
-      onAuthSuccess(response as AuthResponse);
+      onAuthSuccess(response as AuthResponse, 'google');
     }
   };
 

--- a/src/components/common/CourseReviewBox.tsx
+++ b/src/components/common/CourseReviewBox.tsx
@@ -43,6 +43,7 @@ import {
   COURSE_REVIEWS_WITH_USER_DATA,
 } from 'graphql/queries/course/CourseReview';
 import { REFETCH_USER_REVIEW } from 'graphql/queries/user/User';
+import { capture } from 'lib/analytics';
 import { getUserId } from 'utils/Auth';
 import { formatCourseCode } from 'utils/Misc';
 
@@ -315,6 +316,23 @@ const CourseReviewBoxContent = ({
         },
       } as UpsertReviewMutation,
     }).then(() => {
+      const aboutProf = reviewData.prof_id != null;
+      capture('review_posted', {
+        review_type: 'full',
+        is_update: Boolean(review),
+        about_prof: aboutProf,
+        course_id: course.id,
+        course_code: course.code,
+        prof_id: reviewData.prof_id ?? null,
+        liked: reviewData.liked,
+        course_useful: reviewData.course_useful,
+        course_easy: reviewData.course_easy,
+        prof_clear: reviewData.prof_clear ?? null,
+        prof_engaging: reviewData.prof_engaging ?? null,
+        has_course_comment: Boolean(reviewData.course_comment),
+        has_prof_comment: aboutProf && Boolean(reviewData.prof_comment),
+        is_anonymous: !reviewData.public,
+      });
       if (review) {
         notifyUpdate();
       } else {

--- a/src/components/common/CourseReviewBox.tsx
+++ b/src/components/common/CourseReviewBox.tsx
@@ -316,6 +316,15 @@ const CourseReviewBoxContent = ({
         },
       } as UpsertReviewMutation,
     }).then(() => {
+      if (review) {
+        notifyUpdate();
+      } else {
+        notifyInsert();
+      }
+      onCancel();
+      setReviewUpdating(false);
+      // Fire on the side after the UI has settled — capture() defers itself, so
+      // this never blocks the toast/close above.
       const aboutProf = reviewData.prof_id != null;
       capture('review_posted', {
         review_type: 'full',
@@ -333,13 +342,6 @@ const CourseReviewBoxContent = ({
         has_prof_comment: aboutProf && Boolean(reviewData.prof_comment),
         is_anonymous: !reviewData.public,
       });
-      if (review) {
-        notifyUpdate();
-      } else {
-        notifyInsert();
-      }
-      onCancel();
-      setReviewUpdating(false);
     });
   };
 

--- a/src/components/input/LikeCourseToggle.tsx
+++ b/src/components/input/LikeCourseToggle.tsx
@@ -14,6 +14,7 @@ import {
 import { COURSE_REVIEWS_WITH_USER_DATA } from 'graphql/queries/course/CourseReview';
 import { REFETCH_USER_REVIEW } from 'graphql/queries/user/User';
 import useModal from 'hooks/useModal';
+import { capture } from 'lib/analytics';
 import { getUserId } from 'utils/Auth';
 
 import {
@@ -86,6 +87,17 @@ const LikeCourseToggle = ({
 
     const likedValue = liked === targetState ? null : targetState;
     setLiked(likedValue);
+
+    // Toggling off clears the like — that's a removal, not a posted review.
+    if (likedValue !== null) {
+      capture('review_posted', {
+        review_type: 'like',
+        about_prof: false,
+        course_id: courseId,
+        course_code: courseCode,
+        liked: likedValue,
+      });
+    }
 
     upsertLiked({
       variables: { user_id: userId, course_id: courseId, liked: likedValue },

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -51,9 +51,23 @@ export const initAnalytics = (): void => {
   }
 };
 
+// Run analytics work "on the side": defer to a macrotask so the current
+// user-facing flow (toast, navigation, re-render) commits first and analytics
+// never blocks it. PostHog's own send is already async/batched; this just
+// guarantees even the synchronous enqueue happens after the UI has settled.
+const onSide = (fn: () => void): void => {
+  setTimeout(() => {
+    try {
+      fn();
+    } catch {
+      // Analytics must never break the app.
+    }
+  }, 0);
+};
+
 /**
- * Emit a custom product event. No-ops (and never throws) when analytics is
- * disabled, so call sites don't have to guard.
+ * Emit a custom product event. No-ops when analytics is disabled, never throws,
+ * and fires on the side (deferred) so call sites don't block or have to guard.
  */
 export const capture = (
   event: string,
@@ -62,24 +76,17 @@ export const capture = (
   if (!enabled) {
     return;
   }
-  try {
-    posthog.capture(event, properties);
-  } catch {
-    // Analytics must never break the app.
-  }
+  onSide(() => posthog.capture(event, properties));
 };
 
 /**
  * Tie subsequent events to a logged-in user. Call after login/signup so events
  * (and the session that led to them) attach to the user's PostHog person.
+ * Fires on the side, preserving call order (identify before any later capture).
  */
 export const identify = (userId: string | number): void => {
   if (!enabled || userId === null || userId === undefined) {
     return;
   }
-  try {
-    posthog.identify(String(userId));
-  } catch {
-    // Analytics must never break the app.
-  }
+  onSide(() => posthog.identify(String(userId)));
 };

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -4,9 +4,10 @@
  *   import { initAnalytics } from 'lib/analytics';
  *   initAnalytics();  // once, near the app root
  *
- * We don't emit any custom events: PostHog captures pageviews/pageleaves and
- * sessions automatically, and that's the whole of our analytics. PostHog also
- * handles identity, batching, delivery on tab-hide/unload, and Do-Not-Track.
+ * PostHog captures pageviews/pageleaves and sessions automatically, and handles
+ * batching, delivery on tab-hide/unload, and Do-Not-Track. On top of that we
+ * emit a small number of product events via `capture()` (e.g. account_created,
+ * review_posted) and tie them to a user with `identify()` after auth.
  *
  * Configuration (build-time, inlined by CRA's DefinePlugin):
  *   REACT_APP_POSTHOG_KEY  — public PostHog project API key (safe in client JS).
@@ -45,6 +46,39 @@ export const initAnalytics = (): void => {
       respect_dnt: true,
     });
     enabled = true;
+  } catch {
+    // Analytics must never break the app.
+  }
+};
+
+/**
+ * Emit a custom product event. No-ops (and never throws) when analytics is
+ * disabled, so call sites don't have to guard.
+ */
+export const capture = (
+  event: string,
+  properties?: Record<string, unknown>,
+): void => {
+  if (!enabled) {
+    return;
+  }
+  try {
+    posthog.capture(event, properties);
+  } catch {
+    // Analytics must never break the app.
+  }
+};
+
+/**
+ * Tie subsequent events to a logged-in user. Call after login/signup so events
+ * (and the session that led to them) attach to the user's PostHog person.
+ */
+export const identify = (userId: string | number): void => {
+  if (!enabled || userId === null || userId === undefined) {
+    return;
+  }
+  try {
+    posthog.identify(String(userId));
   } catch {
     // Analytics must never break the app.
   }


### PR DESCRIPTION
## What

Adds two custom PostHog events plus user identification, building on the existing `lib/analytics` module.

### `account_created`
Fired once when a new account is created (`is_new` from the auth response), from `AuthForm.onAuthSuccess`.

| Property | Values |
|---|---|
| `method` | `email` \| `google` \| `facebook` |

### `review_posted`
One event for both review shapes — split on `review_type` in PostHog.

- **`review_type: 'full'`** — the rich review form (`CourseReviewBox`). Includes: `about_prof`, `is_update` (edit vs first post), `course_id`/`course_code`, `prof_id`, `liked`, `course_useful`, `course_easy`, `prof_clear`, `prof_engaging`, `has_course_comment`, `has_prof_comment`, `is_anonymous`.
- **`review_type: 'like'`** — the thumbs up/down toggle (`LikeCourseToggle`). Includes `about_prof: false`, `course_id`/`course_code`, `liked`. Toggling a like **off** is a removal, so it emits no event.

### Plumbing
- New `capture(event, props)` and `identify(userId)` helpers in `lib/analytics` — both no-op and never throw when no PostHog key is set (local dev stays a no-op).
- `identify(user_id)` is called after every login/signup so events attach to the user's PostHog person.
- `docs/analytics.md` updated (it previously claimed we emit no custom events).

## Metadata rationale
Beyond the two requested distinctions (simple like vs. full comment; prof vs. not), the extra props let us answer follow-ups without new events: edit vs. first-time review, anonymous rate, comment vs. ratings-only, signup channel, and per-course/per-prof breakdowns. `identify` ties the funnel together (anonymous browse → signup → review).

## Testing
- `bun run lint-nofix` ✅
- `bunx tsc --noEmit` ✅
- Events are no-ops without `REACT_APP_POSTHOG_KEY`, so local dev is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)