### PR TITLE
Course planner page (/plan) with GPA calculator and degree checklists

### DIFF
--- a/.agents/skills/create-component/SKILL.md
+++ b/.agents/skills/create-component/SKILL.md
@@ -47,6 +47,7 @@ arbitrary `[Npx]` values:
 | Font weight | `font-light` 300 / `font-regular` 400 / `font-semibold` 600 / `font-extrabold` 800 |
 | Typography | `text-body` (Inter / 16px / 400) — a config `addUtilities` class; prefer it over repeating `font-inter text-md font-regular` |
 | Radius | `rounded-card` (4px) for cards/chips |
+| Shadows | `shadow-box` for in-page cards, `shadow-modal` for floating prompt cards |
 | Spacing | t-shirt scale: `xs` 4 / `sm` 8 / `md` 16 / `lg` 24 / `xl` 32 (px), plus `page` 32 — e.g. `p-md`, `gap-sm`, `mr-xl` (not `p-4`, `gap-2`, `mr-8`) |
 | Hover | `brightness-hover` (0.85), `duration-hover` (100ms), `ease-hover` (ease-in) — e.g. `transition-all duration-hover ease-hover hover:brightness-hover` |
 | Breakpoints (min) | `mobileLarge` 600, `tablet` 800, `desktop` 1200 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@ as `[Npx]`.
   Tailwind `rounded-md` / `lg` / `xl` (6 / 8 / 12px) for larger surfaces.
 - **Colors**: mirror `src/constants/GlobalTheme.tsx` (`primary`, `dark1`,
   `light2`, `accent`, …). Keep the two files in sync.
+- **Shadows**: `shadow-box` for in-page cards, `shadow-modal` for floating
+  prompt cards/modal content, `shadow-dark-box` / `shadow-bottom-box` for
+  legacy surfaces.
 
 Note: spacing and font-size both expose `sm`/`md`/`lg` keys with different
 pixel values (Tailwind keeps them in separate namespaces). `text-sm` is 14px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import {
   LoadableExplorePage,
   LoadableLandingPage,
   LoadableNotFoundPage,
+  LoadablePlanPage,
   LoadablePrivacyPage,
   LoadableProfilePage,
   LoadableProfPage,
@@ -22,6 +23,7 @@ import {
   COURSE_PAGE_ROUTE,
   EXPLORE_PAGE_ROUTE,
   LANDING_PAGE_ROUTE,
+  PLAN_PAGE_ROUTE,
   PRIVACY_PAGE_ROUTE,
   PROF_PAGE_ROUTE,
   PROFILE_PAGE_ROUTE,
@@ -171,6 +173,11 @@ const App = () => {
           exact
           path={SWAP_PAGE_ROUTE}
           component={() => <LoadableSwapPage />}
+        />
+        <SentryRoute
+          exact
+          path={PLAN_PAGE_ROUTE}
+          component={() => <LoadablePlanPage />}
         />
         <SentryRoute path="*" component={() => <LoadableNotFoundPage />} />
       </Switch>

--- a/src/LoadableComponents.tsx
+++ b/src/LoadableComponents.tsx
@@ -39,3 +39,7 @@ export const LoadableWelcomePage = loadable(
 export const LoadableSwapPage = loadable(
   () => import(/* webpackPrefetch: true */ './pages/swapPage/SwapPage'),
 );
+
+export const LoadablePlanPage = loadable(
+  () => import(/* webpackPrefetch: true */ './pages/planPage/PlanPage'),
+);

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -4,6 +4,7 @@ import { compile, pathToRegexp } from 'path-to-regexp';
 /* Page Routes */
 export const LANDING_PAGE_ROUTE = '/';
 export const PROFILE_PAGE_ROUTE = '/profile';
+export const PLAN_PAGE_ROUTE = '/plan';
 export const SWAP_PAGE_ROUTE = '/swap';
 export const COURSE_PAGE_ROUTE = '/course/:courseCode';
 export const SHORT_PROF_PAGE_ROUTE = '/prof/:profCode';

--- a/src/components/auth/LoginPromptCard.tsx
+++ b/src/components/auth/LoginPromptCard.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Lock } from 'react-feather';
+
+import { Button } from 'components/ui/button';
+import { AUTH_MODAL } from 'constants/Modal';
+import useModal from 'hooks/useModal';
+
+type LoginPromptCardProps = {
+  title: string;
+  description: string;
+};
+
+// Floating "log in to continue" card shown on pages that need an account
+// (plan page, swap page).
+const LoginPromptCard = ({ title, description }: LoginPromptCardProps) => {
+  const [openModal] = useModal();
+
+  return (
+    <div className="flex max-w-[400px] flex-col items-center gap-3 rounded bg-white px-12 py-10 text-center shadow-modal">
+      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-light2 text-dark2">
+        <Lock size={24} />
+      </div>
+      <h2 className="mb-0 mt-1 text-xl font-bold text-dark1">{title}</h2>
+      <p className="m-0 text-sm leading-normal text-dark2">{description}</p>
+      <Button
+        variant="accent"
+        size="lg"
+        className="mt-2"
+        onClick={() => openModal(AUTH_MODAL)}
+      >
+        Log in to continue
+      </Button>
+    </div>
+  );
+};
+
+export default LoginPromptCard;

--- a/src/components/input/CourseSearchDropdown.tsx
+++ b/src/components/input/CourseSearchDropdown.tsx
@@ -8,19 +8,27 @@ import {
 } from 'generated/graphql';
 
 import { COURSE_DROPDOWN_TERM_QUERY } from 'graphql/queries/course/SwapCourse';
+import {
+  COURSE_DROPDOWN_ALL_QUERY,
+  CourseDropdownAllQuery,
+} from 'graphql/queries/planner/Planner';
 import { cn } from 'lib/utils';
 import { formatCourseCode } from 'utils/Misc';
 
 const dropdownEmptyStateClasses =
   'px-3.5 py-4 text-center text-[13px] text-dark3';
 
-type CourseItem = CourseDropdownByTermQuery['course'][number];
+type CourseItem = { code: string; name: string };
 
 type CourseSearchDropdownProps = {
   selectedCode: string | null;
   onSelect: (code: string) => void;
   onClose: () => void;
-  termId: number;
+  // When set, only courses with sections in this term are searchable;
+  // when omitted, every course is.
+  termId?: number;
+  // Tailwind classes positioning the dropdown relative to its parent.
+  positionClasses?: string;
 };
 
 type RowData = {
@@ -65,20 +73,14 @@ const CourseSearchDropdown = ({
   onSelect,
   onClose,
   termId,
+  positionClasses = 'right-0 top-[calc(100%+8px)]',
 }: CourseSearchDropdownProps) => {
   const [searchQuery, setSearchQuery] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
+  }, []);
 
   // Let keyboard users dismiss the dropdown with Escape, matching the
   // pointer-only backdrop click.
@@ -90,12 +92,20 @@ const CourseSearchDropdown = ({
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [onClose]);
 
-  const { data, loading } = useQuery<
+  const byTerm = useQuery<
     CourseDropdownByTermQuery,
     CourseDropdownByTermQueryVariables
-  >(COURSE_DROPDOWN_TERM_QUERY, { variables: { termId } });
+  >(COURSE_DROPDOWN_TERM_QUERY, {
+    variables: { termId: termId ?? 0 },
+    skip: termId === undefined,
+  });
+  const all = useQuery<CourseDropdownAllQuery>(COURSE_DROPDOWN_ALL_QUERY, {
+    skip: termId !== undefined,
+  });
 
-  const allCourses: CourseItem[] = data?.course ?? [];
+  const loading = termId === undefined ? all.loading : byTerm.loading;
+  const allCourses: CourseItem[] =
+    (termId === undefined ? all.data?.course : byTerm.data?.course) ?? [];
 
   // Course codes in the data are lowercase with no space ("cs135"), so a
   // query like "CS 135" matches the `code` key poorly. Run two passes —
@@ -167,7 +177,12 @@ const CourseSearchDropdown = ({
   return (
     <>
       <div className="fixed inset-0 z-[199]" onClick={onClose} />
-      <div className="absolute right-0 top-[calc(100%+8px)] z-[200] flex max-h-[360px] min-w-[300px] flex-col overflow-hidden rounded border border-solid border-light3 bg-white shadow-[0_4px_20px_rgba(0,0,0,0.12)]">
+      <div
+        className={cn(
+          'absolute z-[200] flex max-h-[360px] min-w-[300px] flex-col overflow-hidden rounded border border-solid border-light3 bg-white shadow-[0_4px_20px_rgba(0,0,0,0.12)]',
+          positionClasses,
+        )}
+      >
         <input
           ref={inputRef}
           className="box-border w-full shrink-0 border-0 border-b border-solid border-light2 bg-transparent px-3.5 py-2.5 font-inter text-sm font-normal outline-none placeholder:text-dark3"

--- a/src/components/modal/PageOverlay.tsx
+++ b/src/components/modal/PageOverlay.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { cn } from 'lib/utils';
+
+type PageOverlayProps = {
+  visible: boolean;
+  children: React.ReactNode;
+};
+
+// Full-page frosted overlay that fades in over a page's content, used for
+// first-visit prompts (transcript/schedule upload, login).
+const PageOverlay = ({ visible, children }: PageOverlayProps) => (
+  <div
+    className={cn(
+      'fixed inset-0 z-10 box-border flex items-start justify-center overflow-y-auto bg-white/55 backdrop-blur [transition:opacity_0.4s_ease]',
+      visible
+        ? 'pointer-events-auto opacity-100'
+        : 'pointer-events-none opacity-0',
+    )}
+  >
+    <div className="mt-[150px] flex justify-center">{children}</div>
+  </div>
+);
+
+export default PageOverlay;

--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { PLAN_PAGE_ROUTE } from 'Routes';
 import { useTheme } from 'styled-components';
 
 import { RootState } from 'data/reducers/RootReducer';
@@ -15,6 +17,7 @@ import SearchBar from './SearchBar';
 
 const Navbar = () => {
   const width = useSelector((state: RootState) => state.browser.width);
+  const isLoggedIn = useSelector((state: RootState) => state.auth.loggedIn);
   const theme = useTheme();
 
   return (
@@ -23,6 +26,14 @@ const Navbar = () => {
         <NavbarContent>
           {width >= theme.breakpoints.mobileLarge && <FlowLogo />}
           <SearchBar maximizeWidth />
+          {isLoggedIn && width >= theme.breakpoints.mobileLarge && (
+            <Link
+              to={PLAN_PAGE_ROUTE}
+              className="ml-md text-md font-semibold text-primary no-underline hover:text-primaryDark"
+            >
+              Plan
+            </Link>
+          )}
           <ProfileDropdown />
         </NavbarContent>
       </NavbarWrapper>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { cn } from 'lib/utils';
+
+const Card = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('rounded-lg bg-white p-md shadow-box', className)}
+    {...props}
+  />
+);
+
+const CardHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'mb-sm flex items-center gap-xs text-sm text-dark2',
+      className,
+    )}
+    {...props}
+  />
+);
+
+export { Card, CardHeader };

--- a/src/components/upload/TranscriptUploadModalContent.tsx
+++ b/src/components/upload/TranscriptUploadModalContent.tsx
@@ -24,6 +24,8 @@ import TranscriptUploadVideoMP4 from 'img/upload/transcript-import-chrome.mp4';
 import TranscriptUploadVideoWebm from 'img/upload/transcript-import-chrome.webm';
 import { ErrorResponse, TranscriptParseResponse } from 'types/Api';
 import { makeAuthenticatedPOSTRequest } from 'utils/Api';
+import { getUserId } from 'utils/Auth';
+import { saveTranscriptGrades } from 'utils/Gpa';
 import { sleep } from 'utils/Misc';
 
 import {
@@ -93,12 +95,15 @@ const TranscriptUploadModalContent = ({
     const formData = new FormData();
     formData.append('file', file);
     setUploadState(UPLOAD_PENDING);
-    const [, status] = await makeAuthenticatedPOSTRequest<
+    const [response, status] = await makeAuthenticatedPOSTRequest<
       FormData,
       TranscriptParseResponse | ErrorResponse
     >(`${BACKEND_ENDPOINT}${TRANSCRIPT_PARSE_ENDPOINT}`, formData, {});
 
     if (status === 200) {
+      // Keep parsed grades/units client-side only (for the planner's GPA
+      // calculator); they are never persisted server-side.
+      saveTranscriptGrades(getUserId(), response as TranscriptParseResponse);
       await sleep(500);
       setUploadState(UPLOAD_SUCCESSFUL);
       toast(DATA_UPLOAD_SUCCESS);

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -23,6 +23,7 @@ export type Scalars = {
   bigint: { input: any; output: any };
   date: { input: any; output: any };
   join_source: { input: any; output: any };
+  jsonb: { input: any; output: any };
   numeric: { input: any; output: any };
   smallint: { input: any; output: any };
   timestamptz: { input: any; output: any };
@@ -1945,6 +1946,254 @@ export type Bigint_Comparison_Exp = {
   _lte?: InputMaybe<Scalars['bigint']['input']>;
   _neq?: InputMaybe<Scalars['bigint']['input']>;
   _nin?: InputMaybe<Array<Scalars['bigint']['input']>>;
+};
+
+/** columns and relationships of "checklist" */
+export type Checklist = {
+  __typename?: 'checklist';
+  id: Scalars['Int']['output'];
+  name: Scalars['String']['output'];
+  requirements: Scalars['jsonb']['output'];
+};
+
+/** columns and relationships of "checklist" */
+export type ChecklistRequirementsArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "checklist" */
+export type Checklist_Aggregate = {
+  __typename?: 'checklist_aggregate';
+  aggregate?: Maybe<Checklist_Aggregate_Fields>;
+  nodes: Array<Checklist>;
+};
+
+/** aggregate fields of "checklist" */
+export type Checklist_Aggregate_Fields = {
+  __typename?: 'checklist_aggregate_fields';
+  avg?: Maybe<Checklist_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Checklist_Max_Fields>;
+  min?: Maybe<Checklist_Min_Fields>;
+  stddev?: Maybe<Checklist_Stddev_Fields>;
+  stddev_pop?: Maybe<Checklist_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Checklist_Stddev_Samp_Fields>;
+  sum?: Maybe<Checklist_Sum_Fields>;
+  var_pop?: Maybe<Checklist_Var_Pop_Fields>;
+  var_samp?: Maybe<Checklist_Var_Samp_Fields>;
+  variance?: Maybe<Checklist_Variance_Fields>;
+};
+
+/** aggregate fields of "checklist" */
+export type Checklist_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Checklist_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** append existing jsonb value of filtered columns with new jsonb value */
+export type Checklist_Append_Input = {
+  requirements?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Checklist_Avg_Fields = {
+  __typename?: 'checklist_avg_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "checklist". All fields are combined with a logical 'AND'. */
+export type Checklist_Bool_Exp = {
+  _and?: InputMaybe<Array<Checklist_Bool_Exp>>;
+  _not?: InputMaybe<Checklist_Bool_Exp>;
+  _or?: InputMaybe<Array<Checklist_Bool_Exp>>;
+  id?: InputMaybe<Int_Comparison_Exp>;
+  name?: InputMaybe<String_Comparison_Exp>;
+  requirements?: InputMaybe<Jsonb_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "checklist" */
+export enum Checklist_Constraint {
+  /** unique or primary key constraint on columns "name" */
+  ChecklistNameKey = 'checklist_name_key',
+  /** unique or primary key constraint on columns "id" */
+  ChecklistPkey = 'checklist_pkey',
+}
+
+/** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+export type Checklist_Delete_At_Path_Input = {
+  requirements?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+/** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+export type Checklist_Delete_Elem_Input = {
+  requirements?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** delete key/value pair or string element. key/value pairs are matched based on their key value */
+export type Checklist_Delete_Key_Input = {
+  requirements?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** input type for incrementing numeric columns in table "checklist" */
+export type Checklist_Inc_Input = {
+  id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** input type for inserting data into table "checklist" */
+export type Checklist_Insert_Input = {
+  id?: InputMaybe<Scalars['Int']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  requirements?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** aggregate max on columns */
+export type Checklist_Max_Fields = {
+  __typename?: 'checklist_max_fields';
+  id?: Maybe<Scalars['Int']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Checklist_Min_Fields = {
+  __typename?: 'checklist_min_fields';
+  id?: Maybe<Scalars['Int']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+};
+
+/** response of any mutation on the table "checklist" */
+export type Checklist_Mutation_Response = {
+  __typename?: 'checklist_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int']['output'];
+  /** data from the rows affected by the mutation */
+  returning: Array<Checklist>;
+};
+
+/** on_conflict condition type for table "checklist" */
+export type Checklist_On_Conflict = {
+  constraint: Checklist_Constraint;
+  update_columns?: Array<Checklist_Update_Column>;
+  where?: InputMaybe<Checklist_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "checklist". */
+export type Checklist_Order_By = {
+  id?: InputMaybe<Order_By>;
+  name?: InputMaybe<Order_By>;
+  requirements?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: checklist */
+export type Checklist_Pk_Columns_Input = {
+  id: Scalars['Int']['input'];
+};
+
+/** prepend existing jsonb value of filtered columns with new jsonb value */
+export type Checklist_Prepend_Input = {
+  requirements?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** select columns of table "checklist" */
+export enum Checklist_Select_Column {
+  /** column name */
+  Id = 'id',
+  /** column name */
+  Name = 'name',
+  /** column name */
+  Requirements = 'requirements',
+}
+
+/** input type for updating data in table "checklist" */
+export type Checklist_Set_Input = {
+  id?: InputMaybe<Scalars['Int']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  requirements?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** aggregate stddev on columns */
+export type Checklist_Stddev_Fields = {
+  __typename?: 'checklist_stddev_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Checklist_Stddev_Pop_Fields = {
+  __typename?: 'checklist_stddev_pop_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Checklist_Stddev_Samp_Fields = {
+  __typename?: 'checklist_stddev_samp_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "checklist" */
+export type Checklist_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Checklist_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Checklist_Stream_Cursor_Value_Input = {
+  id?: InputMaybe<Scalars['Int']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  requirements?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Checklist_Sum_Fields = {
+  __typename?: 'checklist_sum_fields';
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** update columns of table "checklist" */
+export enum Checklist_Update_Column {
+  /** column name */
+  Id = 'id',
+  /** column name */
+  Name = 'name',
+  /** column name */
+  Requirements = 'requirements',
+}
+
+export type Checklist_Updates = {
+  /** append existing jsonb value of filtered columns with new jsonb value */
+  _append?: InputMaybe<Checklist_Append_Input>;
+  /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+  _delete_at_path?: InputMaybe<Checklist_Delete_At_Path_Input>;
+  /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+  _delete_elem?: InputMaybe<Checklist_Delete_Elem_Input>;
+  /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+  _delete_key?: InputMaybe<Checklist_Delete_Key_Input>;
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<Checklist_Inc_Input>;
+  /** prepend existing jsonb value of filtered columns with new jsonb value */
+  _prepend?: InputMaybe<Checklist_Prepend_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<Checklist_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: Checklist_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type Checklist_Var_Pop_Fields = {
+  __typename?: 'checklist_var_pop_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Checklist_Var_Samp_Fields = {
+  __typename?: 'checklist_var_samp_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Checklist_Variance_Fields = {
+  __typename?: 'checklist_variance_fields';
+  id?: Maybe<Scalars['Float']['output']>;
 };
 
 /** columns and relationships of "course" */
@@ -4531,9 +4780,41 @@ export type Join_Source_Comparison_Exp = {
   _nin?: InputMaybe<Array<Scalars['join_source']['input']>>;
 };
 
+export type Jsonb_Cast_Exp = {
+  String?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** Boolean expression to compare columns of type "jsonb". All fields are combined with logical 'AND'. */
+export type Jsonb_Comparison_Exp = {
+  _cast?: InputMaybe<Jsonb_Cast_Exp>;
+  /** is the column contained in the given json value */
+  _contained_in?: InputMaybe<Scalars['jsonb']['input']>;
+  /** does the column contain the given json value at the top level */
+  _contains?: InputMaybe<Scalars['jsonb']['input']>;
+  _eq?: InputMaybe<Scalars['jsonb']['input']>;
+  _gt?: InputMaybe<Scalars['jsonb']['input']>;
+  _gte?: InputMaybe<Scalars['jsonb']['input']>;
+  /** does the string exist as a top-level key in the column */
+  _has_key?: InputMaybe<Scalars['String']['input']>;
+  /** do all of these strings exist as top-level keys in the column */
+  _has_keys_all?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** do any of these strings exist as top-level keys in the column */
+  _has_keys_any?: InputMaybe<Array<Scalars['String']['input']>>;
+  _in?: InputMaybe<Array<Scalars['jsonb']['input']>>;
+  _is_null?: InputMaybe<Scalars['Boolean']['input']>;
+  _lt?: InputMaybe<Scalars['jsonb']['input']>;
+  _lte?: InputMaybe<Scalars['jsonb']['input']>;
+  _neq?: InputMaybe<Scalars['jsonb']['input']>;
+  _nin?: InputMaybe<Array<Scalars['jsonb']['input']>>;
+};
+
 /** mutation root */
 export type Mutation_Root = {
   __typename?: 'mutation_root';
+  /** delete data from the table: "checklist" */
+  delete_checklist?: Maybe<Checklist_Mutation_Response>;
+  /** delete single row from the table: "checklist" */
+  delete_checklist_by_pk?: Maybe<Checklist>;
   /** delete data from the table: "course" */
   delete_course?: Maybe<Course_Mutation_Response>;
   /** delete data from the table: "course_antirequisite" */
@@ -4574,12 +4855,20 @@ export type Mutation_Root = {
   delete_user?: Maybe<User_Mutation_Response>;
   /** delete single row from the table: "user" */
   delete_user_by_pk?: Maybe<User>;
+  /** delete data from the table: "user_course_plan" */
+  delete_user_course_plan?: Maybe<User_Course_Plan_Mutation_Response>;
+  /** delete single row from the table: "user_course_plan" */
+  delete_user_course_plan_by_pk?: Maybe<User_Course_Plan>;
   /** delete data from the table: "user_course_taken" */
   delete_user_course_taken?: Maybe<User_Course_Taken_Mutation_Response>;
   /** delete data from the table: "user_schedule" */
   delete_user_schedule?: Maybe<User_Schedule_Mutation_Response>;
   /** delete data from the table: "user_shortlist" */
   delete_user_shortlist?: Maybe<User_Shortlist_Mutation_Response>;
+  /** insert data into the table: "checklist" */
+  insert_checklist?: Maybe<Checklist_Mutation_Response>;
+  /** insert a single row into the table: "checklist" */
+  insert_checklist_one?: Maybe<Checklist>;
   /** insert data into the table: "course" */
   insert_course?: Maybe<Course_Mutation_Response>;
   /** insert data into the table: "course_antirequisite" */
@@ -4634,6 +4923,10 @@ export type Mutation_Root = {
   insert_section_meeting_one?: Maybe<Section_Meeting>;
   /** insert data into the table: "user" */
   insert_user?: Maybe<User_Mutation_Response>;
+  /** insert data into the table: "user_course_plan" */
+  insert_user_course_plan?: Maybe<User_Course_Plan_Mutation_Response>;
+  /** insert a single row into the table: "user_course_plan" */
+  insert_user_course_plan_one?: Maybe<User_Course_Plan>;
   /** insert data into the table: "user_course_taken" */
   insert_user_course_taken?: Maybe<User_Course_Taken_Mutation_Response>;
   /** insert a single row into the table: "user_course_taken" */
@@ -4648,6 +4941,12 @@ export type Mutation_Root = {
   insert_user_shortlist?: Maybe<User_Shortlist_Mutation_Response>;
   /** insert a single row into the table: "user_shortlist" */
   insert_user_shortlist_one?: Maybe<User_Shortlist>;
+  /** update data of the table: "checklist" */
+  update_checklist?: Maybe<Checklist_Mutation_Response>;
+  /** update single row of the table: "checklist" */
+  update_checklist_by_pk?: Maybe<Checklist>;
+  /** update multiples rows of table: "checklist" */
+  update_checklist_many?: Maybe<Array<Maybe<Checklist_Mutation_Response>>>;
   /** update data of the table: "course" */
   update_course?: Maybe<Course_Mutation_Response>;
   /** update data of the table: "course_antirequisite" */
@@ -4734,6 +5033,14 @@ export type Mutation_Root = {
   update_user?: Maybe<User_Mutation_Response>;
   /** update single row of the table: "user" */
   update_user_by_pk?: Maybe<User>;
+  /** update data of the table: "user_course_plan" */
+  update_user_course_plan?: Maybe<User_Course_Plan_Mutation_Response>;
+  /** update single row of the table: "user_course_plan" */
+  update_user_course_plan_by_pk?: Maybe<User_Course_Plan>;
+  /** update multiples rows of table: "user_course_plan" */
+  update_user_course_plan_many?: Maybe<
+    Array<Maybe<User_Course_Plan_Mutation_Response>>
+  >;
   /** update data of the table: "user_course_taken" */
   update_user_course_taken?: Maybe<User_Course_Taken_Mutation_Response>;
   /** update multiples rows of table: "user_course_taken" */
@@ -4754,6 +5061,16 @@ export type Mutation_Root = {
   update_user_shortlist_many?: Maybe<
     Array<Maybe<User_Shortlist_Mutation_Response>>
   >;
+};
+
+/** mutation root */
+export type Mutation_RootDelete_ChecklistArgs = {
+  where: Checklist_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootDelete_Checklist_By_PkArgs = {
+  id: Scalars['Int']['input'];
 };
 
 /** mutation root */
@@ -4857,6 +5174,18 @@ export type Mutation_RootDelete_User_By_PkArgs = {
 };
 
 /** mutation root */
+export type Mutation_RootDelete_User_Course_PlanArgs = {
+  where: User_Course_Plan_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootDelete_User_Course_Plan_By_PkArgs = {
+  course_id: Scalars['Int']['input'];
+  term_id: Scalars['Int']['input'];
+  user_id: Scalars['Int']['input'];
+};
+
+/** mutation root */
 export type Mutation_RootDelete_User_Course_TakenArgs = {
   where: User_Course_Taken_Bool_Exp;
 };
@@ -4869,6 +5198,18 @@ export type Mutation_RootDelete_User_ScheduleArgs = {
 /** mutation root */
 export type Mutation_RootDelete_User_ShortlistArgs = {
   where: User_Shortlist_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_ChecklistArgs = {
+  objects: Array<Checklist_Insert_Input>;
+  on_conflict?: InputMaybe<Checklist_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_Checklist_OneArgs = {
+  object: Checklist_Insert_Input;
+  on_conflict?: InputMaybe<Checklist_On_Conflict>;
 };
 
 /** mutation root */
@@ -5028,6 +5369,18 @@ export type Mutation_RootInsert_UserArgs = {
 };
 
 /** mutation root */
+export type Mutation_RootInsert_User_Course_PlanArgs = {
+  objects: Array<User_Course_Plan_Insert_Input>;
+  on_conflict?: InputMaybe<User_Course_Plan_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_User_Course_Plan_OneArgs = {
+  object: User_Course_Plan_Insert_Input;
+  on_conflict?: InputMaybe<User_Course_Plan_On_Conflict>;
+};
+
+/** mutation root */
 export type Mutation_RootInsert_User_Course_TakenArgs = {
   objects: Array<User_Course_Taken_Insert_Input>;
   on_conflict?: InputMaybe<User_Course_Taken_On_Conflict>;
@@ -5067,6 +5420,35 @@ export type Mutation_RootInsert_User_ShortlistArgs = {
 export type Mutation_RootInsert_User_Shortlist_OneArgs = {
   object: User_Shortlist_Insert_Input;
   on_conflict?: InputMaybe<User_Shortlist_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_ChecklistArgs = {
+  _append?: InputMaybe<Checklist_Append_Input>;
+  _delete_at_path?: InputMaybe<Checklist_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<Checklist_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<Checklist_Delete_Key_Input>;
+  _inc?: InputMaybe<Checklist_Inc_Input>;
+  _prepend?: InputMaybe<Checklist_Prepend_Input>;
+  _set?: InputMaybe<Checklist_Set_Input>;
+  where: Checklist_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_Checklist_By_PkArgs = {
+  _append?: InputMaybe<Checklist_Append_Input>;
+  _delete_at_path?: InputMaybe<Checklist_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<Checklist_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<Checklist_Delete_Key_Input>;
+  _inc?: InputMaybe<Checklist_Inc_Input>;
+  _prepend?: InputMaybe<Checklist_Prepend_Input>;
+  _set?: InputMaybe<Checklist_Set_Input>;
+  pk_columns: Checklist_Pk_Columns_Input;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_Checklist_ManyArgs = {
+  updates: Array<Checklist_Updates>;
 };
 
 /** mutation root */
@@ -5272,6 +5654,25 @@ export type Mutation_RootUpdate_User_By_PkArgs = {
   _inc?: InputMaybe<User_Inc_Input>;
   _set?: InputMaybe<User_Set_Input>;
   pk_columns: User_Pk_Columns_Input;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_User_Course_PlanArgs = {
+  _inc?: InputMaybe<User_Course_Plan_Inc_Input>;
+  _set?: InputMaybe<User_Course_Plan_Set_Input>;
+  where: User_Course_Plan_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_User_Course_Plan_By_PkArgs = {
+  _inc?: InputMaybe<User_Course_Plan_Inc_Input>;
+  _set?: InputMaybe<User_Course_Plan_Set_Input>;
+  pk_columns: User_Course_Plan_Pk_Columns_Input;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_User_Course_Plan_ManyArgs = {
+  updates: Array<User_Course_Plan_Updates>;
 };
 
 /** mutation root */
@@ -6488,6 +6889,12 @@ export type Query_Root = {
   aggregate_prof_review_rating: Array<Aggregate_Prof_Review_Rating>;
   /** fetch aggregated fields from the table: "aggregate.prof_review_rating" */
   aggregate_prof_review_rating_aggregate: Aggregate_Prof_Review_Rating_Aggregate;
+  /** fetch data from the table: "checklist" */
+  checklist: Array<Checklist>;
+  /** fetch aggregated fields from the table: "checklist" */
+  checklist_aggregate: Checklist_Aggregate;
+  /** fetch data from the table: "checklist" using primary key columns */
+  checklist_by_pk?: Maybe<Checklist>;
   /** fetch data from the table: "course" */
   course: Array<Course>;
   /** fetch aggregated fields from the table: "course" */
@@ -6580,6 +6987,12 @@ export type Query_Root = {
   user_aggregate: User_Aggregate;
   /** fetch data from the table: "user" using primary key columns */
   user_by_pk?: Maybe<User>;
+  /** fetch data from the table: "user_course_plan" */
+  user_course_plan: Array<User_Course_Plan>;
+  /** fetch aggregated fields from the table: "user_course_plan" */
+  user_course_plan_aggregate: User_Course_Plan_Aggregate;
+  /** fetch data from the table: "user_course_plan" using primary key columns */
+  user_course_plan_by_pk?: Maybe<User_Course_Plan>;
   /** fetch data from the table: "user_course_taken" */
   user_course_taken: Array<User_Course_Taken>;
   /** fetch aggregated fields from the table: "user_course_taken" */
@@ -6728,6 +7141,26 @@ export type Query_RootAggregate_Prof_Review_Rating_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Aggregate_Prof_Review_Rating_Order_By>>;
   where?: InputMaybe<Aggregate_Prof_Review_Rating_Bool_Exp>;
+};
+
+export type Query_RootChecklistArgs = {
+  distinct_on?: InputMaybe<Array<Checklist_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Checklist_Order_By>>;
+  where?: InputMaybe<Checklist_Bool_Exp>;
+};
+
+export type Query_RootChecklist_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Checklist_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Checklist_Order_By>>;
+  where?: InputMaybe<Checklist_Bool_Exp>;
+};
+
+export type Query_RootChecklist_By_PkArgs = {
+  id: Scalars['Int']['input'];
 };
 
 export type Query_RootCourseArgs = {
@@ -7076,6 +7509,28 @@ export type Query_RootUser_AggregateArgs = {
 
 export type Query_RootUser_By_PkArgs = {
   id: Scalars['Int']['input'];
+};
+
+export type Query_RootUser_Course_PlanArgs = {
+  distinct_on?: InputMaybe<Array<User_Course_Plan_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<User_Course_Plan_Order_By>>;
+  where?: InputMaybe<User_Course_Plan_Bool_Exp>;
+};
+
+export type Query_RootUser_Course_Plan_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<User_Course_Plan_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<User_Course_Plan_Order_By>>;
+  where?: InputMaybe<User_Course_Plan_Bool_Exp>;
+};
+
+export type Query_RootUser_Course_Plan_By_PkArgs = {
+  course_id: Scalars['Int']['input'];
+  term_id: Scalars['Int']['input'];
+  user_id: Scalars['Int']['input'];
 };
 
 export type Query_RootUser_Course_TakenArgs = {
@@ -9357,6 +9812,14 @@ export type Subscription_Root = {
   aggregate_prof_review_rating_aggregate: Aggregate_Prof_Review_Rating_Aggregate;
   /** fetch data from the table in a streaming manner: "aggregate.prof_review_rating" */
   aggregate_prof_review_rating_stream: Array<Aggregate_Prof_Review_Rating>;
+  /** fetch data from the table: "checklist" */
+  checklist: Array<Checklist>;
+  /** fetch aggregated fields from the table: "checklist" */
+  checklist_aggregate: Checklist_Aggregate;
+  /** fetch data from the table: "checklist" using primary key columns */
+  checklist_by_pk?: Maybe<Checklist>;
+  /** fetch data from the table in a streaming manner: "checklist" */
+  checklist_stream: Array<Checklist>;
   /** fetch data from the table: "course" */
   course: Array<Course>;
   /** fetch aggregated fields from the table: "course" */
@@ -9483,6 +9946,14 @@ export type Subscription_Root = {
   user_aggregate: User_Aggregate;
   /** fetch data from the table: "user" using primary key columns */
   user_by_pk?: Maybe<User>;
+  /** fetch data from the table: "user_course_plan" */
+  user_course_plan: Array<User_Course_Plan>;
+  /** fetch aggregated fields from the table: "user_course_plan" */
+  user_course_plan_aggregate: User_Course_Plan_Aggregate;
+  /** fetch data from the table: "user_course_plan" using primary key columns */
+  user_course_plan_by_pk?: Maybe<User_Course_Plan>;
+  /** fetch data from the table in a streaming manner: "user_course_plan" */
+  user_course_plan_stream: Array<User_Course_Plan>;
   /** fetch data from the table: "user_course_taken" */
   user_course_taken: Array<User_Course_Taken>;
   /** fetch aggregated fields from the table: "user_course_taken" */
@@ -9691,6 +10162,32 @@ export type Subscription_RootAggregate_Prof_Review_Rating_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Aggregate_Prof_Review_Rating_Stream_Cursor_Input>>;
   where?: InputMaybe<Aggregate_Prof_Review_Rating_Bool_Exp>;
+};
+
+export type Subscription_RootChecklistArgs = {
+  distinct_on?: InputMaybe<Array<Checklist_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Checklist_Order_By>>;
+  where?: InputMaybe<Checklist_Bool_Exp>;
+};
+
+export type Subscription_RootChecklist_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Checklist_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Checklist_Order_By>>;
+  where?: InputMaybe<Checklist_Bool_Exp>;
+};
+
+export type Subscription_RootChecklist_By_PkArgs = {
+  id: Scalars['Int']['input'];
+};
+
+export type Subscription_RootChecklist_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Checklist_Stream_Cursor_Input>>;
+  where?: InputMaybe<Checklist_Bool_Exp>;
 };
 
 export type Subscription_RootCourseArgs = {
@@ -10143,6 +10640,34 @@ export type Subscription_RootUser_By_PkArgs = {
   id: Scalars['Int']['input'];
 };
 
+export type Subscription_RootUser_Course_PlanArgs = {
+  distinct_on?: InputMaybe<Array<User_Course_Plan_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<User_Course_Plan_Order_By>>;
+  where?: InputMaybe<User_Course_Plan_Bool_Exp>;
+};
+
+export type Subscription_RootUser_Course_Plan_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<User_Course_Plan_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<User_Course_Plan_Order_By>>;
+  where?: InputMaybe<User_Course_Plan_Bool_Exp>;
+};
+
+export type Subscription_RootUser_Course_Plan_By_PkArgs = {
+  course_id: Scalars['Int']['input'];
+  term_id: Scalars['Int']['input'];
+  user_id: Scalars['Int']['input'];
+};
+
+export type Subscription_RootUser_Course_Plan_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<User_Course_Plan_Stream_Cursor_Input>>;
+  where?: InputMaybe<User_Course_Plan_Bool_Exp>;
+};
+
 export type Subscription_RootUser_Course_TakenArgs = {
   distinct_on?: InputMaybe<Array<User_Course_Taken_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -10411,6 +10936,239 @@ export enum User_Constraint {
   /** unique or primary key constraint on columns "secret_id" */
   UserSecretIdKey = 'user_secret_id_key',
 }
+
+/** columns and relationships of "user_course_plan" */
+export type User_Course_Plan = {
+  __typename?: 'user_course_plan';
+  /** An object relationship */
+  course: Course;
+  course_id: Scalars['Int']['output'];
+  term_id: Scalars['Int']['output'];
+  user_id: Scalars['Int']['output'];
+};
+
+/** aggregated selection of "user_course_plan" */
+export type User_Course_Plan_Aggregate = {
+  __typename?: 'user_course_plan_aggregate';
+  aggregate?: Maybe<User_Course_Plan_Aggregate_Fields>;
+  nodes: Array<User_Course_Plan>;
+};
+
+/** aggregate fields of "user_course_plan" */
+export type User_Course_Plan_Aggregate_Fields = {
+  __typename?: 'user_course_plan_aggregate_fields';
+  avg?: Maybe<User_Course_Plan_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<User_Course_Plan_Max_Fields>;
+  min?: Maybe<User_Course_Plan_Min_Fields>;
+  stddev?: Maybe<User_Course_Plan_Stddev_Fields>;
+  stddev_pop?: Maybe<User_Course_Plan_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<User_Course_Plan_Stddev_Samp_Fields>;
+  sum?: Maybe<User_Course_Plan_Sum_Fields>;
+  var_pop?: Maybe<User_Course_Plan_Var_Pop_Fields>;
+  var_samp?: Maybe<User_Course_Plan_Var_Samp_Fields>;
+  variance?: Maybe<User_Course_Plan_Variance_Fields>;
+};
+
+/** aggregate fields of "user_course_plan" */
+export type User_Course_Plan_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<User_Course_Plan_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type User_Course_Plan_Avg_Fields = {
+  __typename?: 'user_course_plan_avg_fields';
+  course_id?: Maybe<Scalars['Float']['output']>;
+  term_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "user_course_plan". All fields are combined with a logical 'AND'. */
+export type User_Course_Plan_Bool_Exp = {
+  _and?: InputMaybe<Array<User_Course_Plan_Bool_Exp>>;
+  _not?: InputMaybe<User_Course_Plan_Bool_Exp>;
+  _or?: InputMaybe<Array<User_Course_Plan_Bool_Exp>>;
+  course?: InputMaybe<Course_Bool_Exp>;
+  course_id?: InputMaybe<Int_Comparison_Exp>;
+  term_id?: InputMaybe<Int_Comparison_Exp>;
+  user_id?: InputMaybe<Int_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "user_course_plan" */
+export enum User_Course_Plan_Constraint {
+  /** unique or primary key constraint on columns "user_id", "term_id", "course_id" */
+  UserCoursePlanPkey = 'user_course_plan_pkey',
+}
+
+/** input type for incrementing numeric columns in table "user_course_plan" */
+export type User_Course_Plan_Inc_Input = {
+  course_id?: InputMaybe<Scalars['Int']['input']>;
+  term_id?: InputMaybe<Scalars['Int']['input']>;
+  user_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** input type for inserting data into table "user_course_plan" */
+export type User_Course_Plan_Insert_Input = {
+  course?: InputMaybe<Course_Obj_Rel_Insert_Input>;
+  course_id?: InputMaybe<Scalars['Int']['input']>;
+  term_id?: InputMaybe<Scalars['Int']['input']>;
+  user_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate max on columns */
+export type User_Course_Plan_Max_Fields = {
+  __typename?: 'user_course_plan_max_fields';
+  course_id?: Maybe<Scalars['Int']['output']>;
+  term_id?: Maybe<Scalars['Int']['output']>;
+  user_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate min on columns */
+export type User_Course_Plan_Min_Fields = {
+  __typename?: 'user_course_plan_min_fields';
+  course_id?: Maybe<Scalars['Int']['output']>;
+  term_id?: Maybe<Scalars['Int']['output']>;
+  user_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** response of any mutation on the table "user_course_plan" */
+export type User_Course_Plan_Mutation_Response = {
+  __typename?: 'user_course_plan_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int']['output'];
+  /** data from the rows affected by the mutation */
+  returning: Array<User_Course_Plan>;
+};
+
+/** on_conflict condition type for table "user_course_plan" */
+export type User_Course_Plan_On_Conflict = {
+  constraint: User_Course_Plan_Constraint;
+  update_columns?: Array<User_Course_Plan_Update_Column>;
+  where?: InputMaybe<User_Course_Plan_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "user_course_plan". */
+export type User_Course_Plan_Order_By = {
+  course?: InputMaybe<Course_Order_By>;
+  course_id?: InputMaybe<Order_By>;
+  term_id?: InputMaybe<Order_By>;
+  user_id?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: user_course_plan */
+export type User_Course_Plan_Pk_Columns_Input = {
+  course_id: Scalars['Int']['input'];
+  term_id: Scalars['Int']['input'];
+  user_id: Scalars['Int']['input'];
+};
+
+/** select columns of table "user_course_plan" */
+export enum User_Course_Plan_Select_Column {
+  /** column name */
+  CourseId = 'course_id',
+  /** column name */
+  TermId = 'term_id',
+  /** column name */
+  UserId = 'user_id',
+}
+
+/** input type for updating data in table "user_course_plan" */
+export type User_Course_Plan_Set_Input = {
+  course_id?: InputMaybe<Scalars['Int']['input']>;
+  term_id?: InputMaybe<Scalars['Int']['input']>;
+  user_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate stddev on columns */
+export type User_Course_Plan_Stddev_Fields = {
+  __typename?: 'user_course_plan_stddev_fields';
+  course_id?: Maybe<Scalars['Float']['output']>;
+  term_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type User_Course_Plan_Stddev_Pop_Fields = {
+  __typename?: 'user_course_plan_stddev_pop_fields';
+  course_id?: Maybe<Scalars['Float']['output']>;
+  term_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type User_Course_Plan_Stddev_Samp_Fields = {
+  __typename?: 'user_course_plan_stddev_samp_fields';
+  course_id?: Maybe<Scalars['Float']['output']>;
+  term_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "user_course_plan" */
+export type User_Course_Plan_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: User_Course_Plan_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type User_Course_Plan_Stream_Cursor_Value_Input = {
+  course_id?: InputMaybe<Scalars['Int']['input']>;
+  term_id?: InputMaybe<Scalars['Int']['input']>;
+  user_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate sum on columns */
+export type User_Course_Plan_Sum_Fields = {
+  __typename?: 'user_course_plan_sum_fields';
+  course_id?: Maybe<Scalars['Int']['output']>;
+  term_id?: Maybe<Scalars['Int']['output']>;
+  user_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** update columns of table "user_course_plan" */
+export enum User_Course_Plan_Update_Column {
+  /** column name */
+  CourseId = 'course_id',
+  /** column name */
+  TermId = 'term_id',
+  /** column name */
+  UserId = 'user_id',
+}
+
+export type User_Course_Plan_Updates = {
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<User_Course_Plan_Inc_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<User_Course_Plan_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: User_Course_Plan_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type User_Course_Plan_Var_Pop_Fields = {
+  __typename?: 'user_course_plan_var_pop_fields';
+  course_id?: Maybe<Scalars['Float']['output']>;
+  term_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type User_Course_Plan_Var_Samp_Fields = {
+  __typename?: 'user_course_plan_var_samp_fields';
+  course_id?: Maybe<Scalars['Float']['output']>;
+  term_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type User_Course_Plan_Variance_Fields = {
+  __typename?: 'user_course_plan_variance_fields';
+  course_id?: Maybe<Scalars['Float']['output']>;
+  term_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
 
 /** columns and relationships of "user_course_taken" */
 export type User_Course_Taken = {
@@ -11878,6 +12636,37 @@ export type UserCoursesTakenFragment = {
   } | null;
 };
 
+export type InsertUserCoursePlanMutationVariables = Exact<{
+  user_id: number;
+  course_id: number;
+  term_id: number;
+}>;
+
+export type InsertUserCoursePlanMutation = {
+  insert_user_course_plan: { affected_rows: number } | null;
+};
+
+export type DeleteUserCoursePlanMutationVariables = Exact<{
+  course_id: number;
+  term_id: number;
+}>;
+
+export type DeleteUserCoursePlanMutation = {
+  delete_user_course_plan: { affected_rows: number } | null;
+};
+
+export type MoveUserCoursePlanMutationVariables = Exact<{
+  user_id: number;
+  course_id: number;
+  from_term_id: number;
+  to_term_id: number;
+}>;
+
+export type MoveUserCoursePlanMutation = {
+  delete_user_course_plan: { affected_rows: number } | null;
+  insert_user_course_plan: { affected_rows: number } | null;
+};
+
 export type UpdateUserEmailMutationVariables = Exact<{
   user_id?: number | null | undefined;
   email?: string | null | undefined;
@@ -12176,6 +12965,40 @@ export type ExploreQueryVariables = Exact<{
 export type ExploreQuery = {
   search_courses: Array<CourseSearchFragment>;
   search_profs: Array<ProfSearchFragment>;
+};
+
+export type GetPlannerDataQueryVariables = Exact<{
+  id?: number | null | undefined;
+}>;
+
+export type GetPlannerDataQuery = {
+  user: Array<{ id: number; program: string | null }>;
+  user_course_taken: Array<{
+    term_id: number;
+    level: string | null;
+    course_id: number | null;
+    course: { id: number; code: string; name: string } | null;
+  }>;
+  user_course_plan: Array<{
+    term_id: number;
+    course_id: number;
+    course: {
+      id: number;
+      code: string;
+      name: string;
+      prerequisites: Array<{
+        is_corequisite: boolean;
+        prerequisite: { id: number; code: string } | null;
+      }>;
+    };
+  }>;
+  checklist: Array<{ id: number; name: string; requirements: any }>;
+};
+
+export type CourseDropdownAllQueryVariables = Exact<{ [key: string]: never }>;
+
+export type CourseDropdownAllQuery = {
+  course: Array<{ id: number; code: string; name: string }>;
 };
 
 export type GetProfQueryVariables = Exact<{
@@ -12658,6 +13481,186 @@ export const SwapCourseSectionFragmentDoc = gql`
     }
   }
 `;
+export const InsertUserCoursePlanDocument = gql`
+  mutation insertUserCoursePlan(
+    $user_id: Int!
+    $course_id: Int!
+    $term_id: Int!
+  ) {
+    insert_user_course_plan(
+      objects: { user_id: $user_id, course_id: $course_id, term_id: $term_id }
+    ) {
+      affected_rows
+    }
+  }
+`;
+export type InsertUserCoursePlanMutationFn = Apollo.MutationFunction<
+  InsertUserCoursePlanMutation,
+  InsertUserCoursePlanMutationVariables
+>;
+
+/**
+ * __useInsertUserCoursePlanMutation__
+ *
+ * To run a mutation, you first call `useInsertUserCoursePlanMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useInsertUserCoursePlanMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [insertUserCoursePlanMutation, { data, loading, error }] = useInsertUserCoursePlanMutation({
+ *   variables: {
+ *      user_id: // value for 'user_id'
+ *      course_id: // value for 'course_id'
+ *      term_id: // value for 'term_id'
+ *   },
+ * });
+ */
+export function useInsertUserCoursePlanMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    InsertUserCoursePlanMutation,
+    InsertUserCoursePlanMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    InsertUserCoursePlanMutation,
+    InsertUserCoursePlanMutationVariables
+  >(InsertUserCoursePlanDocument, options);
+}
+export type InsertUserCoursePlanMutationHookResult = ReturnType<
+  typeof useInsertUserCoursePlanMutation
+>;
+export type InsertUserCoursePlanMutationResult =
+  Apollo.MutationResult<InsertUserCoursePlanMutation>;
+export type InsertUserCoursePlanMutationOptions = Apollo.BaseMutationOptions<
+  InsertUserCoursePlanMutation,
+  InsertUserCoursePlanMutationVariables
+>;
+export const DeleteUserCoursePlanDocument = gql`
+  mutation deleteUserCoursePlan($course_id: Int!, $term_id: Int!) {
+    delete_user_course_plan(
+      where: { course_id: { _eq: $course_id }, term_id: { _eq: $term_id } }
+    ) {
+      affected_rows
+    }
+  }
+`;
+export type DeleteUserCoursePlanMutationFn = Apollo.MutationFunction<
+  DeleteUserCoursePlanMutation,
+  DeleteUserCoursePlanMutationVariables
+>;
+
+/**
+ * __useDeleteUserCoursePlanMutation__
+ *
+ * To run a mutation, you first call `useDeleteUserCoursePlanMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteUserCoursePlanMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteUserCoursePlanMutation, { data, loading, error }] = useDeleteUserCoursePlanMutation({
+ *   variables: {
+ *      course_id: // value for 'course_id'
+ *      term_id: // value for 'term_id'
+ *   },
+ * });
+ */
+export function useDeleteUserCoursePlanMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    DeleteUserCoursePlanMutation,
+    DeleteUserCoursePlanMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    DeleteUserCoursePlanMutation,
+    DeleteUserCoursePlanMutationVariables
+  >(DeleteUserCoursePlanDocument, options);
+}
+export type DeleteUserCoursePlanMutationHookResult = ReturnType<
+  typeof useDeleteUserCoursePlanMutation
+>;
+export type DeleteUserCoursePlanMutationResult =
+  Apollo.MutationResult<DeleteUserCoursePlanMutation>;
+export type DeleteUserCoursePlanMutationOptions = Apollo.BaseMutationOptions<
+  DeleteUserCoursePlanMutation,
+  DeleteUserCoursePlanMutationVariables
+>;
+export const MoveUserCoursePlanDocument = gql`
+  mutation moveUserCoursePlan(
+    $user_id: Int!
+    $course_id: Int!
+    $from_term_id: Int!
+    $to_term_id: Int!
+  ) {
+    delete_user_course_plan(
+      where: { course_id: { _eq: $course_id }, term_id: { _eq: $from_term_id } }
+    ) {
+      affected_rows
+    }
+    insert_user_course_plan(
+      objects: {
+        user_id: $user_id
+        course_id: $course_id
+        term_id: $to_term_id
+      }
+    ) {
+      affected_rows
+    }
+  }
+`;
+export type MoveUserCoursePlanMutationFn = Apollo.MutationFunction<
+  MoveUserCoursePlanMutation,
+  MoveUserCoursePlanMutationVariables
+>;
+
+/**
+ * __useMoveUserCoursePlanMutation__
+ *
+ * To run a mutation, you first call `useMoveUserCoursePlanMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useMoveUserCoursePlanMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [moveUserCoursePlanMutation, { data, loading, error }] = useMoveUserCoursePlanMutation({
+ *   variables: {
+ *      user_id: // value for 'user_id'
+ *      course_id: // value for 'course_id'
+ *      from_term_id: // value for 'from_term_id'
+ *      to_term_id: // value for 'to_term_id'
+ *   },
+ * });
+ */
+export function useMoveUserCoursePlanMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    MoveUserCoursePlanMutation,
+    MoveUserCoursePlanMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    MoveUserCoursePlanMutation,
+    MoveUserCoursePlanMutationVariables
+  >(MoveUserCoursePlanDocument, options);
+}
+export type MoveUserCoursePlanMutationHookResult = ReturnType<
+  typeof useMoveUserCoursePlanMutation
+>;
+export type MoveUserCoursePlanMutationResult =
+  Apollo.MutationResult<MoveUserCoursePlanMutation>;
+export type MoveUserCoursePlanMutationOptions = Apollo.BaseMutationOptions<
+  MoveUserCoursePlanMutation,
+  MoveUserCoursePlanMutationVariables
+>;
 export const UpdateUserEmailDocument = gql`
   mutation updateUserEmail($user_id: Int, $email: String) {
     update_user(where: { id: { _eq: $user_id } }, _set: { email: $email }) {
@@ -14958,6 +15961,240 @@ export type ExploreSuspenseQueryHookResult = ReturnType<
 export type ExploreQueryResult = Apollo.QueryResult<
   ExploreQuery,
   ExploreQueryVariables
+>;
+export const GetPlannerDataDocument = gql`
+  query getPlannerData($id: Int) {
+    user(where: { id: { _eq: $id } }) {
+      id
+      program
+    }
+    user_course_taken(where: { user_id: { _eq: $id } }) {
+      term_id
+      level
+      course_id
+      course {
+        id
+        code
+        name
+      }
+    }
+    user_course_plan(
+      where: { user_id: { _eq: $id } }
+      order_by: { course_id: asc }
+    ) {
+      term_id
+      course_id
+      course {
+        id
+        code
+        name
+        prerequisites {
+          is_corequisite
+          prerequisite {
+            id
+            code
+          }
+        }
+      }
+    }
+    checklist(order_by: { name: asc }) {
+      id
+      name
+      requirements
+    }
+  }
+`;
+
+/**
+ * __useGetPlannerDataQuery__
+ *
+ * To run a query within a React component, call `useGetPlannerDataQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetPlannerDataQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetPlannerDataQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetPlannerDataQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetPlannerDataQuery,
+    GetPlannerDataQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetPlannerDataQuery, GetPlannerDataQueryVariables>(
+    GetPlannerDataDocument,
+    options,
+  );
+}
+export function useGetPlannerDataLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetPlannerDataQuery,
+    GetPlannerDataQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GetPlannerDataQuery, GetPlannerDataQueryVariables>(
+    GetPlannerDataDocument,
+    options,
+  );
+}
+// @ts-ignore
+export function useGetPlannerDataSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GetPlannerDataQuery,
+    GetPlannerDataQueryVariables
+  >,
+): Apollo.UseSuspenseQueryResult<
+  GetPlannerDataQuery,
+  GetPlannerDataQueryVariables
+>;
+export function useGetPlannerDataSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetPlannerDataQuery,
+        GetPlannerDataQueryVariables
+      >,
+): Apollo.UseSuspenseQueryResult<
+  GetPlannerDataQuery | undefined,
+  GetPlannerDataQueryVariables
+>;
+export function useGetPlannerDataSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetPlannerDataQuery,
+        GetPlannerDataQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetPlannerDataQuery,
+    GetPlannerDataQueryVariables
+  >(GetPlannerDataDocument, options);
+}
+export type GetPlannerDataQueryHookResult = ReturnType<
+  typeof useGetPlannerDataQuery
+>;
+export type GetPlannerDataLazyQueryHookResult = ReturnType<
+  typeof useGetPlannerDataLazyQuery
+>;
+export type GetPlannerDataSuspenseQueryHookResult = ReturnType<
+  typeof useGetPlannerDataSuspenseQuery
+>;
+export type GetPlannerDataQueryResult = Apollo.QueryResult<
+  GetPlannerDataQuery,
+  GetPlannerDataQueryVariables
+>;
+export const CourseDropdownAllDocument = gql`
+  query courseDropdownAll {
+    course(order_by: { code: asc }) {
+      id
+      code
+      name
+    }
+  }
+`;
+
+/**
+ * __useCourseDropdownAllQuery__
+ *
+ * To run a query within a React component, call `useCourseDropdownAllQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCourseDropdownAllQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useCourseDropdownAllQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useCourseDropdownAllQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    CourseDropdownAllQuery,
+    CourseDropdownAllQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    CourseDropdownAllQuery,
+    CourseDropdownAllQueryVariables
+  >(CourseDropdownAllDocument, options);
+}
+export function useCourseDropdownAllLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    CourseDropdownAllQuery,
+    CourseDropdownAllQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    CourseDropdownAllQuery,
+    CourseDropdownAllQueryVariables
+  >(CourseDropdownAllDocument, options);
+}
+// @ts-ignore
+export function useCourseDropdownAllSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    CourseDropdownAllQuery,
+    CourseDropdownAllQueryVariables
+  >,
+): Apollo.UseSuspenseQueryResult<
+  CourseDropdownAllQuery,
+  CourseDropdownAllQueryVariables
+>;
+export function useCourseDropdownAllSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        CourseDropdownAllQuery,
+        CourseDropdownAllQueryVariables
+      >,
+): Apollo.UseSuspenseQueryResult<
+  CourseDropdownAllQuery | undefined,
+  CourseDropdownAllQueryVariables
+>;
+export function useCourseDropdownAllSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        CourseDropdownAllQuery,
+        CourseDropdownAllQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    CourseDropdownAllQuery,
+    CourseDropdownAllQueryVariables
+  >(CourseDropdownAllDocument, options);
+}
+export type CourseDropdownAllQueryHookResult = ReturnType<
+  typeof useCourseDropdownAllQuery
+>;
+export type CourseDropdownAllLazyQueryHookResult = ReturnType<
+  typeof useCourseDropdownAllLazyQuery
+>;
+export type CourseDropdownAllSuspenseQueryHookResult = ReturnType<
+  typeof useCourseDropdownAllSuspenseQuery
+>;
+export type CourseDropdownAllQueryResult = Apollo.QueryResult<
+  CourseDropdownAllQuery,
+  CourseDropdownAllQueryVariables
 >;
 export const GetProfDocument = gql`
   query getProf($code: String) {

--- a/src/graphql/__tests__/cache.test.ts
+++ b/src/graphql/__tests__/cache.test.ts
@@ -1,4 +1,5 @@
 import { cache } from '../apollo';
+import { GET_PLANNER_DATA } from '../queries/planner/Planner';
 
 /**
  * Exercises the real `InMemoryCache` `typePolicies` from `apollo.js` (rather
@@ -63,5 +64,63 @@ describe('Apollo InMemoryCache normalization (typePolicies keyFields)', () => {
     expect(cache.identify({ __typename: 'course', id: 123 })).toBe(
       'course:123',
     );
+  });
+
+  it('keys user_course_plan by user_id + term_id + course_id', () => {
+    expect(
+      cache.identify({
+        __typename: 'user_course_plan',
+        user_id: 5,
+        term_id: 1259,
+        course_id: 11,
+      }),
+    ).toBe('user_course_plan:{"user_id":5,"term_id":1259,"course_id":11}');
+  });
+
+  // Regression: the planner query once omitted user_id from user_course_plan,
+  // so writing its result threw ("Missing field 'user_id'") and /plan hung on
+  // the loading spinner. Writing a real result must select every keyField.
+  it('can write a getPlannerData result (selection covers all keyFields)', () => {
+    expect(() =>
+      cache.writeQuery({
+        query: GET_PLANNER_DATA,
+        variables: { id: 5 },
+        data: {
+          user: [{ __typename: 'user', id: 5, program: 'CS' }],
+          user_course_taken: [
+            {
+              __typename: 'user_course_taken',
+              term_id: 1239,
+              level: '1A',
+              course_id: 1,
+              course: { __typename: 'course', id: 1, code: 'cs135', name: 'x' },
+            },
+          ],
+          user_course_plan: [
+            {
+              __typename: 'user_course_plan',
+              user_id: 5,
+              term_id: 1259,
+              course_id: 2,
+              course: {
+                __typename: 'course',
+                id: 2,
+                code: 'cs136',
+                name: 'y',
+                prerequisites: [],
+              },
+            },
+          ],
+          checklist: [
+            {
+              __typename: 'checklist',
+              id: 1,
+              name: 'Honours CS',
+              requirements: [],
+            },
+          ],
+        },
+      }),
+    ).not.toThrow();
   });
 });

--- a/src/graphql/apollo.js
+++ b/src/graphql/apollo.js
@@ -73,6 +73,9 @@ export const cache = new InMemoryCache({
     user_course_taken: {
       keyFields: ['term_id', 'course_id'],
     },
+    user_course_plan: {
+      keyFields: ['user_id', 'term_id', 'course_id'],
+    },
     user_schedule: {
       // `user_id` plus the nested `section.id`. The trailing `['id']` declares
       // the subfields of the preceding `section` object field — this is not the

--- a/src/graphql/mutations/CoursePlan.tsx
+++ b/src/graphql/mutations/CoursePlan.tsx
@@ -1,0 +1,51 @@
+import { gql } from '@apollo/client';
+
+export const INSERT_USER_COURSE_PLAN = gql`
+  mutation insertUserCoursePlan(
+    $user_id: Int!
+    $course_id: Int!
+    $term_id: Int!
+  ) {
+    insert_user_course_plan(
+      objects: { user_id: $user_id, course_id: $course_id, term_id: $term_id }
+    ) {
+      affected_rows
+    }
+  }
+`;
+
+export const DELETE_USER_COURSE_PLAN = gql`
+  mutation deleteUserCoursePlan($course_id: Int!, $term_id: Int!) {
+    delete_user_course_plan(
+      where: { course_id: { _eq: $course_id }, term_id: { _eq: $term_id } }
+    ) {
+      affected_rows
+    }
+  }
+`;
+
+// Both root fields run in a single Hasura transaction, so a move can't
+// half-apply.
+export const MOVE_USER_COURSE_PLAN = gql`
+  mutation moveUserCoursePlan(
+    $user_id: Int!
+    $course_id: Int!
+    $from_term_id: Int!
+    $to_term_id: Int!
+  ) {
+    delete_user_course_plan(
+      where: { course_id: { _eq: $course_id }, term_id: { _eq: $from_term_id } }
+    ) {
+      affected_rows
+    }
+    insert_user_course_plan(
+      objects: {
+        user_id: $user_id
+        course_id: $course_id
+        term_id: $to_term_id
+      }
+    ) {
+      affected_rows
+    }
+  }
+`;

--- a/src/graphql/queries/planner/Planner.tsx
+++ b/src/graphql/queries/planner/Planner.tsx
@@ -1,0 +1,101 @@
+import { gql } from '@apollo/client';
+
+// NOTE: types for these documents are hand-written below rather than
+// generated: `bun run generate` needs a live Hasura instance that already has
+// the checklist/user_course_plan migration applied. Regenerate and swap these
+// out next time codegen is run.
+
+export const GET_PLANNER_DATA = gql`
+  query getPlannerData($id: Int) {
+    user(where: { id: { _eq: $id } }) {
+      id
+      program
+    }
+    user_course_taken(where: { user_id: { _eq: $id } }) {
+      term_id
+      level
+      course_id
+      course {
+        id
+        code
+        name
+      }
+    }
+    user_course_plan(
+      where: { user_id: { _eq: $id } }
+      order_by: { course_id: asc }
+    ) {
+      term_id
+      course_id
+      course {
+        id
+        code
+        name
+        prerequisites {
+          is_corequisite
+          prerequisite {
+            id
+            code
+          }
+        }
+      }
+    }
+    checklist(order_by: { name: asc }) {
+      id
+      name
+      requirements
+    }
+  }
+`;
+
+// Every course, for the planner's "Add course" search. Cached and shared by
+// Apollo between the dropdown and the page.
+export const COURSE_DROPDOWN_ALL_QUERY = gql`
+  query courseDropdownAll {
+    course(order_by: { code: asc }) {
+      id
+      code
+      name
+    }
+  }
+`;
+
+/* Hand-written result types (see note above). */
+
+export type PlannerPrerequisite = {
+  is_corequisite: boolean | null;
+  prerequisite: { id: number; code: string } | null;
+};
+
+export type PlannerDataQuery = {
+  user: { id: number; program: string | null }[];
+  user_course_taken: {
+    term_id: number;
+    level: string | null;
+    course_id: number;
+    course: { id: number; code: string; name: string } | null;
+  }[];
+  user_course_plan: {
+    term_id: number;
+    course_id: number;
+    course: {
+      id: number;
+      code: string;
+      name: string;
+      prerequisites: PlannerPrerequisite[];
+    } | null;
+  }[];
+  checklist: {
+    id: number;
+    name: string;
+    // Ordered categories of requirements; each requirement is a list of
+    // alternative course codes ("one of").
+    requirements: { category: string; courses: string[][] }[];
+  }[];
+};
+
+export type PlannerDataQueryVariables = { id: number };
+
+export type CourseDropdownAllQuery = {
+  course: { id: number; code: string; name: string }[];
+};

--- a/src/graphql/queries/planner/Planner.tsx
+++ b/src/graphql/queries/planner/Planner.tsx
@@ -25,6 +25,7 @@ export const GET_PLANNER_DATA = gql`
       where: { user_id: { _eq: $id } }
       order_by: { course_id: asc }
     ) {
+      user_id
       term_id
       course_id
       course {
@@ -76,6 +77,7 @@ export type PlannerDataQuery = {
     course: { id: number; code: string; name: string } | null;
   }[];
   user_course_plan: {
+    user_id: number;
     term_id: number;
     course_id: number;
     course: {

--- a/src/pages/planPage/ChecklistSidebar.tsx
+++ b/src/pages/planPage/ChecklistSidebar.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { CheckCircle, CheckSquare, Circle, X } from 'react-feather';
+import { Link } from 'react-router-dom';
+import { getCoursePageRoute } from 'Routes';
+
+import { PlannerDataQuery } from 'graphql/queries/planner/Planner';
+import { cn } from 'lib/utils';
+import { formatCourseCode } from 'utils/Misc';
+
+import { evaluateChecklist } from './planner';
+
+type Checklist = PlannerDataQuery['checklist'][number];
+
+type ChecklistCardProps = {
+  checklist: Checklist;
+  haveCodes: Set<string>;
+  onRemove: (id: number) => void;
+};
+
+const ChecklistCard = ({
+  checklist,
+  haveCodes,
+  onRemove,
+}: ChecklistCardProps) => {
+  const categories = evaluateChecklist(checklist.requirements, haveCodes);
+  const total = categories.reduce((sum, c) => sum + c.items.length, 0);
+  const met = categories.reduce((sum, c) => sum + c.metCount, 0);
+
+  return (
+    <div className="rounded-lg bg-white p-md shadow-box">
+      <div className="mb-sm flex items-center gap-xs text-sm text-dark2">
+        <CheckSquare size={16} />
+        <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+          {checklist.name}
+        </span>
+        <button
+          type="button"
+          aria-label={`Remove ${checklist.name}`}
+          className="shrink-0 cursor-pointer border-0 bg-transparent p-0 text-dark3 hover:text-red"
+          onClick={() => onRemove(checklist.id)}
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      <div className="text-2xl font-semibold text-dark1">
+        {met} / {total} <span className="text-sm font-regular">met</span>
+      </div>
+      <div className="mb-md mt-sm h-[8px] w-full rounded-full bg-light2">
+        <div
+          className="h-full rounded-full bg-professors transition-[width] duration-500"
+          style={{ width: `${total > 0 ? (met / total) * 100 : 0}%` }}
+        />
+      </div>
+
+      {categories.map((category) => (
+        <div key={category.category} className="mb-md last:mb-0">
+          <div className="mb-sm flex items-baseline justify-between">
+            <span className="text-sm font-semibold text-dark1">
+              {category.category}
+            </span>
+            <span
+              className={cn(
+                'text-xs font-semibold',
+                category.metCount === category.items.length
+                  ? 'text-professors'
+                  : 'text-dark3',
+              )}
+            >
+              {category.metCount}/{category.items.length}
+            </span>
+          </div>
+          <div className="flex flex-col gap-xs">
+            {category.items.map((item) => {
+              const displayCode = item.matched ?? item.alternatives[0];
+              const label = item.matched
+                ? formatCourseCode(item.matched)
+                : item.alternatives.map(formatCourseCode).join(' / ');
+              return (
+                <div
+                  key={item.alternatives.join('-')}
+                  className="flex items-center gap-sm"
+                >
+                  {item.matched ? (
+                    <CheckCircle
+                      size={14}
+                      className="shrink-0 text-professors"
+                    />
+                  ) : (
+                    <Circle size={14} className="shrink-0 text-light4" />
+                  )}
+                  <Link
+                    to={getCoursePageRoute(displayCode)}
+                    className="overflow-hidden text-ellipsis whitespace-nowrap text-xs font-semibold text-courses no-underline hover:underline"
+                  >
+                    {label}
+                  </Link>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+type ChecklistSidebarProps = {
+  checklists: Checklist[];
+  selectedIds: number[];
+  haveCodes: Set<string>;
+  onSelect: (ids: number[]) => void;
+};
+
+const ChecklistSidebar = ({
+  checklists,
+  selectedIds,
+  haveCodes,
+  onSelect,
+}: ChecklistSidebarProps) => {
+  const selected = selectedIds
+    .map((id) => checklists.find((checklist) => checklist.id === id))
+    .filter((checklist): checklist is Checklist => checklist !== undefined);
+  const available = checklists.filter(
+    (checklist) => !selectedIds.includes(checklist.id),
+  );
+
+  return (
+    <>
+      {selected.map((checklist) => (
+        <ChecklistCard
+          key={checklist.id}
+          checklist={checklist}
+          haveCodes={haveCodes}
+          onRemove={(id) => onSelect(selectedIds.filter((s) => s !== id))}
+        />
+      ))}
+      {available.length > 0 && (
+        <select
+          className="w-full cursor-pointer rounded-card border border-solid border-light3 bg-white p-sm font-inter text-sm text-dark2"
+          value=""
+          onChange={(e) => {
+            const id = Number(e.target.value);
+            if (id) onSelect([...selectedIds, id]);
+          }}
+        >
+          <option value="">
+            {selected.length > 0
+              ? 'Import another checklist…'
+              : 'Import a degree checklist…'}
+          </option>
+          {available.map((checklist) => (
+            <option key={checklist.id} value={checklist.id}>
+              {checklist.name}
+            </option>
+          ))}
+        </select>
+      )}
+    </>
+  );
+};
+
+export default ChecklistSidebar;

--- a/src/pages/planPage/ChecklistSidebar.tsx
+++ b/src/pages/planPage/ChecklistSidebar.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import { CheckCircle, CheckSquare, Circle, X } from 'react-feather';
+import { CheckCircle, CheckSquare, Circle } from 'react-feather';
 import { Link } from 'react-router-dom';
 import { getCoursePageRoute } from 'Routes';
 
+import { Card, CardHeader } from 'components/ui/card';
 import { PlannerDataQuery } from 'graphql/queries/planner/Planner';
 import { cn } from 'lib/utils';
 import { formatCourseCode } from 'utils/Misc';
 
 import { evaluateChecklist } from './planner';
+import RemoveButton from './RemoveButton';
 
 type Checklist = PlannerDataQuery['checklist'][number];
 
@@ -27,21 +29,17 @@ const ChecklistCard = ({
   const met = categories.reduce((sum, c) => sum + c.metCount, 0);
 
   return (
-    <div className="rounded-lg bg-white p-md shadow-box">
-      <div className="mb-sm flex items-center gap-xs text-sm text-dark2">
+    <Card>
+      <CardHeader>
         <CheckSquare size={16} />
         <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
           {checklist.name}
         </span>
-        <button
-          type="button"
-          aria-label={`Remove ${checklist.name}`}
-          className="shrink-0 cursor-pointer border-0 bg-transparent p-0 text-dark3 hover:text-red"
+        <RemoveButton
+          label={`Remove ${checklist.name}`}
           onClick={() => onRemove(checklist.id)}
-        >
-          <X size={14} />
-        </button>
-      </div>
+        />
+      </CardHeader>
 
       <div className="text-2xl font-semibold text-dark1">
         {met} / {total} <span className="text-sm font-regular">met</span>
@@ -101,7 +99,7 @@ const ChecklistCard = ({
           </div>
         </div>
       ))}
-    </div>
+    </Card>
   );
 };
 

--- a/src/pages/planPage/GpaCard.tsx
+++ b/src/pages/planPage/GpaCard.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Award } from 'react-feather';
+
+import { TRANSCRIPT_UPLOAD_MODAL } from 'constants/Modal';
+import useModal from 'hooks/useModal';
+import { computeGpa, computeTermGpas, TranscriptGradeStore } from 'utils/Gpa';
+import { termCodeToDate } from 'utils/Misc';
+
+type GpaCardProps = {
+  gradeStore: TranscriptGradeStore | null;
+  onAfterUploadSuccess: () => void;
+};
+
+const GpaCard = ({ gradeStore, onAfterUploadSuccess }: GpaCardProps) => {
+  const [openModal, closeModal] = useModal();
+
+  const cumulativeGpa = gradeStore
+    ? computeGpa(Object.values(gradeStore))
+    : null;
+  const termGpas = gradeStore ? computeTermGpas(gradeStore) : [];
+
+  return (
+    <div className="rounded-lg bg-white p-md shadow-box">
+      <div className="mb-sm flex items-center gap-xs text-sm text-dark2">
+        <Award size={16} />
+        GPA · OMSAS 4.0 scale
+      </div>
+      {cumulativeGpa === null ? (
+        <>
+          <p className="m-0 mb-sm text-xs leading-normal text-dark2">
+            Upload your transcript to calculate your GPA. Your grades never
+            leave this browser — we don&apos;t store them.
+          </p>
+          <button
+            type="button"
+            className="cursor-pointer rounded border-none bg-accent px-md py-sm text-sm font-semibold text-dark1 transition-[filter] duration-100 ease-in hover:brightness-95"
+            onClick={() =>
+              openModal(TRANSCRIPT_UPLOAD_MODAL, {
+                onAfterUploadSuccess,
+                onSkip: () => closeModal(TRANSCRIPT_UPLOAD_MODAL),
+              })
+            }
+          >
+            Upload transcript
+          </button>
+        </>
+      ) : (
+        <>
+          <div className="text-2xl font-semibold text-dark1">
+            {cumulativeGpa.toFixed(2)}
+          </div>
+          <div className="mb-sm text-xs text-dark3">
+            cumulative, credit-weighted
+          </div>
+          <div className="flex flex-col gap-xs">
+            {termGpas.map(({ termId, gpa }) => (
+              <div
+                key={termId}
+                className="flex justify-between text-xs text-dark2"
+              >
+                <span>{termCodeToDate(termId)}</span>
+                <span className="font-semibold text-dark1">
+                  {gpa.toFixed(2)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default GpaCard;

--- a/src/pages/planPage/GpaCard.tsx
+++ b/src/pages/planPage/GpaCard.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Award } from 'react-feather';
 
+import { Button } from 'components/ui/button';
+import { Card, CardHeader } from 'components/ui/card';
 import { TRANSCRIPT_UPLOAD_MODAL } from 'constants/Modal';
 import useModal from 'hooks/useModal';
 import { computeGpa, computeTermGpas, TranscriptGradeStore } from 'utils/Gpa';
@@ -20,20 +22,19 @@ const GpaCard = ({ gradeStore, onAfterUploadSuccess }: GpaCardProps) => {
   const termGpas = gradeStore ? computeTermGpas(gradeStore) : [];
 
   return (
-    <div className="rounded-lg bg-white p-md shadow-box">
-      <div className="mb-sm flex items-center gap-xs text-sm text-dark2">
+    <Card>
+      <CardHeader>
         <Award size={16} />
         GPA · OMSAS 4.0 scale
-      </div>
+      </CardHeader>
       {cumulativeGpa === null ? (
         <>
           <p className="m-0 mb-sm text-xs leading-normal text-dark2">
             Upload your transcript to calculate your GPA. Your grades never
             leave this browser — we don&apos;t store them.
           </p>
-          <button
-            type="button"
-            className="cursor-pointer rounded border-none bg-accent px-md py-sm text-sm font-semibold text-dark1 transition-[filter] duration-100 ease-in hover:brightness-95"
+          <Button
+            variant="accent"
             onClick={() =>
               openModal(TRANSCRIPT_UPLOAD_MODAL, {
                 onAfterUploadSuccess,
@@ -42,7 +43,7 @@ const GpaCard = ({ gradeStore, onAfterUploadSuccess }: GpaCardProps) => {
             }
           >
             Upload transcript
-          </button>
+          </Button>
         </>
       ) : (
         <>
@@ -67,7 +68,7 @@ const GpaCard = ({ gradeStore, onAfterUploadSuccess }: GpaCardProps) => {
           </div>
         </>
       )}
-    </div>
+    </Card>
   );
 };
 

--- a/src/pages/planPage/PlanPage.tsx
+++ b/src/pages/planPage/PlanPage.tsx
@@ -44,7 +44,7 @@ const PlanPage = () => {
   const [openModal] = useModal();
   const userId = getUserId();
 
-  const { loading, data, refetch } = useQuery<
+  const { loading, error, data, refetch } = useQuery<
     PlannerDataQuery,
     PlannerDataQueryVariables
   >(GET_PLANNER_DATA, { variables: { id: userId }, skip: !isLoggedIn });
@@ -212,6 +212,26 @@ const PlanPage = () => {
               Log in to continue
             </button>
           </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={planPageWrapperClasses}>
+        {helmet}
+        <div className="flex flex-col items-center gap-sm pt-[150px] text-center">
+          <p className="m-0 text-md text-dark2">
+            Couldn&apos;t load your plan — please try again.
+          </p>
+          <button
+            type="button"
+            className="cursor-pointer rounded border-none bg-accent px-md py-sm text-sm font-semibold text-dark1 transition-[filter] duration-100 ease-in hover:brightness-95"
+            onClick={() => refetch()}
+          >
+            Retry
+          </button>
         </div>
       </div>
     );

--- a/src/pages/planPage/PlanPage.tsx
+++ b/src/pages/planPage/PlanPage.tsx
@@ -1,0 +1,317 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { BookOpen, Lock } from 'react-feather';
+import { Helmet } from 'react-helmet';
+import { useSelector } from 'react-redux';
+import { toast } from 'react-toastify';
+import { useMutation, useQuery } from '@apollo/client';
+
+import LoadingSpinner from 'components/display/LoadingSpinner';
+import TranscriptUploadModalContent from 'components/upload/TranscriptUploadModalContent';
+import { AUTH_MODAL } from 'constants/Modal';
+import { RootState } from 'data/reducers/RootReducer';
+import {
+  DELETE_USER_COURSE_PLAN,
+  INSERT_USER_COURSE_PLAN,
+  MOVE_USER_COURSE_PLAN,
+} from 'graphql/mutations/CoursePlan';
+import {
+  COURSE_DROPDOWN_ALL_QUERY,
+  CourseDropdownAllQuery,
+  GET_PLANNER_DATA,
+  PlannerDataQuery,
+  PlannerDataQueryVariables,
+} from 'graphql/queries/planner/Planner';
+import useModal from 'hooks/useModal';
+import { cn } from 'lib/utils';
+import { getUserId } from 'utils/Auth';
+import { loadTranscriptGrades } from 'utils/Gpa';
+import { formatCourseCode, getCurrentTermCode } from 'utils/Misc';
+
+import ChecklistSidebar from './ChecklistSidebar';
+import GpaCard from './GpaCard';
+import {
+  buildTerms,
+  computePrereqWarnings,
+  PlanRow,
+  toPlanRows,
+} from './planner';
+import TermCard from './TermCard';
+
+const planPageWrapperClasses = 'min-h-page w-full bg-light1 pb-xl';
+
+const PlanPage = () => {
+  const isLoggedIn = useSelector((state: RootState) => state.auth.loggedIn);
+  const [openModal] = useModal();
+  const userId = getUserId();
+
+  const { loading, data, refetch } = useQuery<
+    PlannerDataQuery,
+    PlannerDataQueryVariables
+  >(GET_PLANNER_DATA, { variables: { id: userId }, skip: !isLoggedIn });
+  const allCoursesQuery = useQuery<CourseDropdownAllQuery>(
+    COURSE_DROPDOWN_ALL_QUERY,
+    { skip: !isLoggedIn },
+  );
+
+  const [insertPlan] = useMutation(INSERT_USER_COURSE_PLAN);
+  const [deletePlan] = useMutation(DELETE_USER_COURSE_PLAN);
+  const [movePlan] = useMutation(MOVE_USER_COURSE_PLAN);
+
+  // Plan rows are edited optimistically and re-synced whenever the query
+  // refetches (mutations refetch on error, adds refetch to pick up prereqs).
+  const [planRows, setPlanRows] = useState<PlanRow[]>([]);
+  useEffect(() => {
+    if (data) setPlanRows(toPlanRows(data.user_course_plan));
+  }, [data]);
+
+  // Grades live only in localStorage; bump gradeVersion to re-read after an
+  // upload.
+  const [gradeVersion, setGradeVersion] = useState(0);
+  const gradeStore = useMemo(
+    () =>
+      isLoggedIn && gradeVersion >= 0 ? loadTranscriptGrades(userId) : null,
+    [isLoggedIn, userId, gradeVersion],
+  );
+
+  const checklistStorageKey = `plan_checklists_${userId}`;
+  const [selectedChecklists, setSelectedChecklists] = useState<number[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(checklistStorageKey) || '[]');
+    } catch {
+      return [];
+    }
+  });
+  const selectChecklists = (ids: number[]) => {
+    setSelectedChecklists(ids);
+    localStorage.setItem(checklistStorageKey, JSON.stringify(ids));
+  };
+
+  const terms = useMemo(
+    () =>
+      data
+        ? buildTerms(
+            data.user_course_taken,
+            planRows,
+            getCurrentTermCode(),
+            gradeStore,
+          )
+        : [],
+    [data, planRows, gradeStore],
+  );
+  const warnings = useMemo(() => computePrereqWarnings(terms), [terms]);
+
+  const haveCodes = useMemo(
+    () =>
+      new Set(
+        terms.flatMap((term) => term.courses.map((course) => course.code)),
+      ),
+    [terms],
+  );
+
+  const onMutationError = () => {
+    toast('Failed to save your plan — please try again');
+    refetch();
+  };
+
+  const handleAddCourse = (termId: number, code: string) => {
+    if (haveCodes.has(code)) {
+      toast(`${formatCourseCode(code)} is already in your plan`);
+      return;
+    }
+    const course = allCoursesQuery.data?.course.find((c) => c.code === code);
+    if (!course) return;
+    setPlanRows((rows) => [
+      ...rows,
+      { termId, courseId: course.id, code, name: course.name, prereqs: [] },
+    ]);
+    insertPlan({
+      variables: { user_id: userId, course_id: course.id, term_id: termId },
+    })
+      // Refetch to pick up the new course's prerequisites for warnings.
+      .then(() => refetch())
+      .catch(onMutationError);
+  };
+
+  const handleRemoveCourse = (termId: number, courseId: number) => {
+    setPlanRows((rows) =>
+      rows.filter(
+        (row) => !(row.termId === termId && row.courseId === courseId),
+      ),
+    );
+    deletePlan({ variables: { course_id: courseId, term_id: termId } }).catch(
+      onMutationError,
+    );
+  };
+
+  const handleMoveCourse = (
+    courseId: number,
+    fromTermId: number,
+    toTermId: number,
+  ) => {
+    if (fromTermId === toTermId) return;
+    setPlanRows((rows) =>
+      rows.map((row) =>
+        row.termId === fromTermId && row.courseId === courseId
+          ? { ...row, termId: toTermId }
+          : row,
+      ),
+    );
+    movePlan({
+      variables: {
+        user_id: userId,
+        course_id: courseId,
+        from_term_id: fromTermId,
+        to_term_id: toTermId,
+      },
+    }).catch(onMutationError);
+  };
+
+  const totalUnits = terms.reduce(
+    (sum, term) =>
+      sum + term.courses.reduce((termSum, course) => termSum + course.units, 0),
+    0,
+  );
+  const totalCourses = terms.reduce(
+    (sum, term) => sum + term.courses.length,
+    0,
+  );
+  const hasTranscript = (data?.user_course_taken.length ?? 0) > 0;
+  const program = data?.user[0]?.program;
+
+  const helmet = (
+    <Helmet>
+      <title>Plan - UW Flow</title>
+      <meta
+        name="description"
+        content="Plan your degree term by term: import your transcript, check prerequisites and degree requirements, and calculate your GPA."
+      />
+    </Helmet>
+  );
+
+  if (!isLoggedIn) {
+    return (
+      <div className={planPageWrapperClasses}>
+        {helmet}
+        <div className="flex justify-center pt-[150px]">
+          <div className="flex max-w-[400px] flex-col items-center gap-3 rounded bg-white px-12 py-10 text-center shadow-[0_8px_32px_rgba(23,43,77,0.16)]">
+            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-light2 text-dark2">
+              <Lock size={24} />
+            </div>
+            <h2 className="mb-0 mt-1 text-xl font-bold text-dark1">
+              Log in to plan your degree
+            </h2>
+            <p className="m-0 text-sm leading-normal text-dark2">
+              Import your transcript to see the courses you&apos;ve taken, plan
+              future terms, track degree requirements, and calculate your GPA.
+            </p>
+            <button
+              type="button"
+              className="mt-2 cursor-pointer rounded border-none bg-accent px-7 py-3 text-[15px] font-semibold text-dark1 transition-[filter] duration-100 ease-in hover:brightness-95"
+              onClick={() => openModal(AUTH_MODAL)}
+            >
+              Log in to continue
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading || !data) {
+    return (
+      <div className={planPageWrapperClasses}>
+        {helmet}
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className={planPageWrapperClasses}>
+      {helmet}
+
+      <div className="bg-dark1 px-page py-lg text-white">
+        <div className="mx-auto flex max-w-[1400px] flex-wrap items-center gap-lg">
+          <div className="min-w-0 flex-1">
+            <div className="mb-xs flex items-center gap-xs text-xs text-light4">
+              <BookOpen size={14} />
+              Course planner
+            </div>
+            <h1 className="m-0 text-2xl font-extrabold">
+              {program || 'Your degree'}
+            </h1>
+            <p className="m-0 mt-xs text-sm text-light4">
+              Drag courses between terms · add from search · we check
+              prerequisites as you go
+            </p>
+          </div>
+          <div className="flex gap-lg">
+            {[
+              [totalUnits.toFixed(1), 'units planned'],
+              [String(totalCourses), 'courses'],
+              [String(terms.length), 'terms'],
+            ].map(([value, label]) => (
+              <div key={label} className="text-right">
+                <div className="text-2xl font-semibold">{value}</div>
+                <div className="text-xs text-light4">{label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto flex max-w-[1400px] animate-fade-in flex-col gap-md px-md pt-md desktop:flex-row">
+        <div className="grid flex-1 auto-rows-min grid-cols-[repeat(auto-fill,minmax(230px,1fr))] gap-md">
+          {terms.map((term) => (
+            <TermCard
+              key={term.termId}
+              term={term}
+              warnings={warnings}
+              onAddCourse={handleAddCourse}
+              onRemoveCourse={handleRemoveCourse}
+              onMoveCourse={handleMoveCourse}
+            />
+          ))}
+        </div>
+        <div className="flex w-full shrink-0 flex-col gap-md desktop:w-[320px]">
+          <GpaCard
+            gradeStore={gradeStore}
+            onAfterUploadSuccess={() => {
+              setGradeVersion((version) => version + 1);
+              refetch();
+            }}
+          />
+          <ChecklistSidebar
+            checklists={data.checklist}
+            selectedIds={selectedChecklists}
+            haveCodes={haveCodes}
+            onSelect={selectChecklists}
+          />
+        </div>
+      </div>
+
+      {/* First visit: prompt for a transcript import, like the swap page. */}
+      <div
+        className={cn(
+          'fixed inset-0 z-10 box-border flex items-start justify-center overflow-y-auto bg-white/55 backdrop-blur [transition:opacity_0.4s_ease]',
+          !hasTranscript
+            ? 'pointer-events-auto opacity-100'
+            : 'pointer-events-none opacity-0',
+        )}
+      >
+        {!hasTranscript && (
+          <div className="mt-[150px] flex justify-center">
+            <TranscriptUploadModalContent
+              onAfterUploadSuccess={() => {
+                setGradeVersion((version) => version + 1);
+                refetch();
+              }}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PlanPage;

--- a/src/pages/planPage/PlanPage.tsx
+++ b/src/pages/planPage/PlanPage.tsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { BookOpen, Lock } from 'react-feather';
+import { BookOpen } from 'react-feather';
 import { Helmet } from 'react-helmet';
 import { useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
 import { useMutation, useQuery } from '@apollo/client';
 
+import LoginPromptCard from 'components/auth/LoginPromptCard';
 import LoadingSpinner from 'components/display/LoadingSpinner';
+import PageOverlay from 'components/modal/PageOverlay';
+import { Button } from 'components/ui/button';
 import TranscriptUploadModalContent from 'components/upload/TranscriptUploadModalContent';
-import { AUTH_MODAL } from 'constants/Modal';
 import { RootState } from 'data/reducers/RootReducer';
 import {
   DELETE_USER_COURSE_PLAN,
@@ -21,8 +23,6 @@ import {
   PlannerDataQuery,
   PlannerDataQueryVariables,
 } from 'graphql/queries/planner/Planner';
-import useModal from 'hooks/useModal';
-import { cn } from 'lib/utils';
 import { getUserId } from 'utils/Auth';
 import { loadTranscriptGrades } from 'utils/Gpa';
 import { formatCourseCode, getCurrentTermCode } from 'utils/Misc';
@@ -41,7 +41,6 @@ const planPageWrapperClasses = 'min-h-page w-full bg-light1 pb-xl';
 
 const PlanPage = () => {
   const isLoggedIn = useSelector((state: RootState) => state.auth.loggedIn);
-  const [openModal] = useModal();
   const userId = getUserId();
 
   const { loading, error, data, refetch } = useQuery<
@@ -193,25 +192,10 @@ const PlanPage = () => {
       <div className={planPageWrapperClasses}>
         {helmet}
         <div className="flex justify-center pt-[150px]">
-          <div className="flex max-w-[400px] flex-col items-center gap-3 rounded bg-white px-12 py-10 text-center shadow-[0_8px_32px_rgba(23,43,77,0.16)]">
-            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-light2 text-dark2">
-              <Lock size={24} />
-            </div>
-            <h2 className="mb-0 mt-1 text-xl font-bold text-dark1">
-              Log in to plan your degree
-            </h2>
-            <p className="m-0 text-sm leading-normal text-dark2">
-              Import your transcript to see the courses you&apos;ve taken, plan
-              future terms, track degree requirements, and calculate your GPA.
-            </p>
-            <button
-              type="button"
-              className="mt-2 cursor-pointer rounded border-none bg-accent px-7 py-3 text-[15px] font-semibold text-dark1 transition-[filter] duration-100 ease-in hover:brightness-95"
-              onClick={() => openModal(AUTH_MODAL)}
-            >
-              Log in to continue
-            </button>
-          </div>
+          <LoginPromptCard
+            title="Log in to plan your degree"
+            description="Import your transcript to see the courses you've taken, plan future terms, track degree requirements, and calculate your GPA."
+          />
         </div>
       </div>
     );
@@ -221,17 +205,16 @@ const PlanPage = () => {
     return (
       <div className={planPageWrapperClasses}>
         {helmet}
-        <div className="flex flex-col items-center gap-sm pt-[150px] text-center">
-          <p className="m-0 text-md text-dark2">
+        {/* Same banner treatment as the 404 page's PageHeader. */}
+        <div className="flex h-[150px] w-full items-end bg-primaryExtraDark pb-xl text-center tabletDown:h-auto tabletDown:px-md tabletDown:py-xl">
+          <p className="mx-auto my-0 w-full max-w-[1200px] px-xl font-anderson text-2xl font-extrabold text-white tablet:text-3xl tabletDown:px-0">
             Couldn&apos;t load your plan — please try again.
           </p>
-          <button
-            type="button"
-            className="cursor-pointer rounded border-none bg-accent px-md py-sm text-sm font-semibold text-dark1 transition-[filter] duration-100 ease-in hover:brightness-95"
-            onClick={() => refetch()}
-          >
+        </div>
+        <div className="flex justify-center pt-lg">
+          <Button variant="accent" onClick={() => refetch()}>
             Retry
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -311,25 +294,16 @@ const PlanPage = () => {
       </div>
 
       {/* First visit: prompt for a transcript import, like the swap page. */}
-      <div
-        className={cn(
-          'fixed inset-0 z-10 box-border flex items-start justify-center overflow-y-auto bg-white/55 backdrop-blur [transition:opacity_0.4s_ease]',
-          !hasTranscript
-            ? 'pointer-events-auto opacity-100'
-            : 'pointer-events-none opacity-0',
-        )}
-      >
+      <PageOverlay visible={!hasTranscript}>
         {!hasTranscript && (
-          <div className="mt-[150px] flex justify-center">
-            <TranscriptUploadModalContent
-              onAfterUploadSuccess={() => {
-                setGradeVersion((version) => version + 1);
-                refetch();
-              }}
-            />
-          </div>
+          <TranscriptUploadModalContent
+            onAfterUploadSuccess={() => {
+              setGradeVersion((version) => version + 1);
+              refetch();
+            }}
+          />
         )}
-      </div>
+      </PageOverlay>
     </div>
   );
 };

--- a/src/pages/planPage/RemoveButton.tsx
+++ b/src/pages/planPage/RemoveButton.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { X } from 'react-feather';
+
+type RemoveButtonProps = {
+  label: string;
+  onClick: () => void;
+};
+
+const RemoveButton = ({ label, onClick }: RemoveButtonProps) => (
+  <button
+    type="button"
+    aria-label={label}
+    className="shrink-0 cursor-pointer border-0 bg-transparent p-0 text-dark3 hover:text-red"
+    onClick={onClick}
+  >
+    <X size={14} />
+  </button>
+);
+
+export default RemoveButton;

--- a/src/pages/planPage/TermCard.tsx
+++ b/src/pages/planPage/TermCard.tsx
@@ -1,0 +1,192 @@
+import React, { DragEvent, useRef, useState } from 'react';
+import { AlertTriangle, Check, Menu, Plus, X } from 'react-feather';
+import { Link } from 'react-router-dom';
+import { getCoursePageRoute } from 'Routes';
+
+import CourseSearchDropdown from 'components/input/CourseSearchDropdown';
+import { cn } from 'lib/utils';
+import { formatCourseCode, termCodeToDate } from 'utils/Misc';
+
+import { PlannerTerm } from './planner';
+
+const DRAG_MIME = 'application/x-uwflow-plan-course';
+
+type TermCardProps = {
+  term: PlannerTerm;
+  // "needs CODE" prereq warnings keyed by `${termId}-${courseId}`
+  warnings: Map<string, string>;
+  onAddCourse: (termId: number, code: string) => void;
+  onRemoveCourse: (termId: number, courseId: number) => void;
+  onMoveCourse: (
+    courseId: number,
+    fromTermId: number,
+    toTermId: number,
+  ) => void;
+};
+
+const TermCard = ({
+  term,
+  warnings,
+  onAddCourse,
+  onRemoveCourse,
+  onMoveCourse,
+}: TermCardProps) => {
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
+  // dragenter/dragleave fire for every child; count them so the highlight
+  // doesn't flicker while dragging across course rows.
+  const dragDepth = useRef(0);
+
+  const totalUnits = term.courses.reduce(
+    (sum, course) => sum + course.units,
+    0,
+  );
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    dragDepth.current = 0;
+    setDragOver(false);
+    try {
+      const payload = JSON.parse(e.dataTransfer.getData(DRAG_MIME));
+      onMoveCourse(payload.courseId, payload.fromTermId, term.termId);
+    } catch {
+      // Not one of our drags; ignore.
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        'flex min-h-[220px] flex-col rounded-lg bg-white p-md shadow-box',
+        !term.taken && dragOver && 'ring-2 ring-primary',
+      )}
+      onDragOver={(e) => {
+        if (!term.taken && e.dataTransfer.types.includes(DRAG_MIME)) {
+          e.preventDefault();
+        }
+      }}
+      onDragEnter={(e) => {
+        if (term.taken || !e.dataTransfer.types.includes(DRAG_MIME)) return;
+        dragDepth.current += 1;
+        setDragOver(true);
+      }}
+      onDragLeave={() => {
+        if (term.taken) return;
+        dragDepth.current = Math.max(0, dragDepth.current - 1);
+        if (dragDepth.current === 0) setDragOver(false);
+      }}
+      onDrop={term.taken ? undefined : handleDrop}
+    >
+      <div className="mb-md flex items-center gap-sm">
+        {term.level && (
+          <span className="text-lg font-extrabold text-dark1">
+            {term.level}
+          </span>
+        )}
+        <span className="text-xs text-dark3">
+          {termCodeToDate(term.termId)}
+        </span>
+        {term.taken && (
+          <span className="flex items-center gap-xs text-xs font-semibold text-professors">
+            <Check size={12} strokeWidth={3} />
+            taken
+          </span>
+        )}
+        <span
+          className={cn(
+            'ml-auto whitespace-nowrap rounded-full px-sm py-xs text-xs font-semibold',
+            term.taken
+              ? 'bg-professors/10 text-professors'
+              : 'bg-accent/20 text-dark2',
+          )}
+        >
+          {totalUnits.toFixed(1)} units
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-sm">
+        {term.courses.map((course) => {
+          const warning = warnings.get(`${term.termId}-${course.courseId}`);
+          return (
+            <div
+              key={course.courseId}
+              draggable={!term.taken}
+              onDragStart={(e) => {
+                e.dataTransfer.setData(
+                  DRAG_MIME,
+                  JSON.stringify({
+                    courseId: course.courseId,
+                    fromTermId: term.termId,
+                  }),
+                );
+                e.dataTransfer.effectAllowed = 'move';
+              }}
+              className={cn(
+                'flex items-center gap-sm rounded-card border border-solid bg-white px-sm py-sm',
+                warning ? 'border-courses' : 'border-light3',
+                !term.taken && 'cursor-grab active:cursor-grabbing',
+              )}
+            >
+              {!term.taken && (
+                <Menu size={12} className="shrink-0 text-light4" />
+              )}
+              <div className="min-w-0 flex-1">
+                <Link
+                  to={getCoursePageRoute(course.code)}
+                  className="text-sm font-semibold text-courses no-underline hover:underline"
+                >
+                  {formatCourseCode(course.code)}
+                </Link>
+                {warning && (
+                  <div className="flex items-center gap-xs text-xs font-semibold text-red">
+                    <AlertTriangle size={11} />
+                    needs {formatCourseCode(warning)}
+                  </div>
+                )}
+                <div className="overflow-hidden text-ellipsis whitespace-nowrap text-xs text-dark3">
+                  {course.name}
+                </div>
+              </div>
+              {!term.taken && (
+                <button
+                  type="button"
+                  aria-label={`Remove ${formatCourseCode(course.code)}`}
+                  className="shrink-0 cursor-pointer border-0 bg-transparent p-0 text-dark3 hover:text-red"
+                  onClick={() => onRemoveCourse(term.termId, course.courseId)}
+                >
+                  <X size={14} />
+                </button>
+              )}
+            </div>
+          );
+        })}
+
+        {!term.taken && (
+          <div className="relative">
+            <button
+              type="button"
+              className="flex w-full cursor-pointer items-center justify-center gap-xs rounded-card border border-dashed border-light4 bg-transparent py-sm text-sm text-dark2 hover:border-primary hover:text-primary"
+              onClick={() => setSearchOpen(true)}
+            >
+              <Plus size={14} />
+              Add course
+            </button>
+            {searchOpen && (
+              <CourseSearchDropdown
+                selectedCode={null}
+                onSelect={(code) => {
+                  setSearchOpen(false);
+                  onAddCourse(term.termId, code);
+                }}
+                onClose={() => setSearchOpen(false)}
+                positionClasses="left-0 top-[calc(100%+4px)]"
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TermCard;

--- a/src/pages/planPage/TermCard.tsx
+++ b/src/pages/planPage/TermCard.tsx
@@ -1,13 +1,15 @@
 import React, { DragEvent, useRef, useState } from 'react';
-import { AlertTriangle, Check, Menu, Plus, X } from 'react-feather';
+import { AlertTriangle, Check, Menu, Plus } from 'react-feather';
 import { Link } from 'react-router-dom';
 import { getCoursePageRoute } from 'Routes';
 
 import CourseSearchDropdown from 'components/input/CourseSearchDropdown';
+import { Card } from 'components/ui/card';
 import { cn } from 'lib/utils';
 import { formatCourseCode, termCodeToDate } from 'utils/Misc';
 
 import { PlannerTerm } from './planner';
+import RemoveButton from './RemoveButton';
 
 const DRAG_MIME = 'application/x-uwflow-plan-course';
 
@@ -55,9 +57,9 @@ const TermCard = ({
   };
 
   return (
-    <div
+    <Card
       className={cn(
-        'flex min-h-[220px] flex-col rounded-lg bg-white p-md shadow-box',
+        'flex min-h-[220px] flex-col',
         !term.taken && dragOver && 'ring-2 ring-primary',
       )}
       onDragOver={(e) => {
@@ -148,14 +150,10 @@ const TermCard = ({
                 </div>
               </div>
               {!term.taken && (
-                <button
-                  type="button"
-                  aria-label={`Remove ${formatCourseCode(course.code)}`}
-                  className="shrink-0 cursor-pointer border-0 bg-transparent p-0 text-dark3 hover:text-red"
+                <RemoveButton
+                  label={`Remove ${formatCourseCode(course.code)}`}
                   onClick={() => onRemoveCourse(term.termId, course.courseId)}
-                >
-                  <X size={14} />
-                </button>
+                />
               )}
             </div>
           );
@@ -185,7 +183,7 @@ const TermCard = ({
           </div>
         )}
       </div>
-    </div>
+    </Card>
   );
 };
 

--- a/src/pages/planPage/__tests__/planner.test.ts
+++ b/src/pages/planPage/__tests__/planner.test.ts
@@ -1,0 +1,177 @@
+import { computeGpa, percentToGpa } from 'utils/Gpa';
+
+import {
+  buildTerms,
+  computePrereqWarnings,
+  evaluateChecklist,
+  nextMajorTermCode,
+} from '../planner';
+
+describe('percentToGpa (OMSAS)', () => {
+  it('maps boundary percentages', () => {
+    expect(percentToGpa(90)).toBe(4.0);
+    expect(percentToGpa(89)).toBe(3.9);
+    expect(percentToGpa(85)).toBe(3.9);
+    expect(percentToGpa(80)).toBe(3.7);
+    expect(percentToGpa(77)).toBe(3.3);
+    expect(percentToGpa(73)).toBe(3.0);
+    expect(percentToGpa(70)).toBe(2.7);
+    expect(percentToGpa(67)).toBe(2.3);
+    expect(percentToGpa(63)).toBe(2.0);
+    expect(percentToGpa(60)).toBe(1.7);
+    expect(percentToGpa(57)).toBe(1.3);
+    expect(percentToGpa(53)).toBe(1.0);
+    expect(percentToGpa(50)).toBe(0.7);
+    expect(percentToGpa(49)).toBe(0.0);
+  });
+});
+
+describe('computeGpa', () => {
+  it('weights by units and skips ungraded courses', () => {
+    const gpa = computeGpa([
+      { units: 0.5, grade: 95 }, // 4.0
+      { units: 0.25, grade: 78 }, // 3.3
+      { units: 0.5, grade: null }, // CR, excluded
+      { units: 0, grade: 90 }, // no units, excluded
+    ]);
+    expect(gpa).toBeCloseTo((4.0 * 0.5 + 3.3 * 0.25) / 0.75, 5);
+  });
+
+  it('returns null with nothing gradable', () => {
+    expect(computeGpa([{ units: 0.5, grade: null }])).toBeNull();
+  });
+});
+
+describe('nextMajorTermCode', () => {
+  it('skips spring terms', () => {
+    expect(nextMajorTermCode(1249)).toBe(1251); // Fall 2024 -> Winter 2025
+    expect(nextMajorTermCode(1251)).toBe(1259); // Winter 2025 -> Fall 2025
+    expect(nextMajorTermCode(1255)).toBe(1259); // Spring 2025 -> Fall 2025
+  });
+});
+
+const takenRow = (termId: number, level: string, id: number, code: string) => ({
+  term_id: termId,
+  level,
+  course_id: id,
+  course: { id, code, name: code.toUpperCase() },
+});
+
+describe('buildTerms', () => {
+  it('continues the level sequence after the transcript up to 4B', () => {
+    const terms = buildTerms(
+      [takenRow(1239, '1A', 1, 'cs135'), takenRow(1241, '1B', 2, 'cs136')],
+      [],
+      1249,
+      null,
+    );
+    expect(terms.map((t) => t.level)).toEqual([
+      '1A',
+      '1B',
+      '2A',
+      '2B',
+      '3A',
+      '3B',
+      '4A',
+      '4B',
+    ]);
+    expect(terms.map((t) => t.taken)).toEqual([
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
+    // 1B is Winter 2024 (1241); next major terms are Fall 2024, Winter 2025, …
+    expect(terms[2].termId).toBe(1249);
+    expect(terms[3].termId).toBe(1251);
+  });
+
+  it('slots planned courses into their terms with default units', () => {
+    const terms = buildTerms(
+      [takenRow(1239, '1A', 1, 'cs135')],
+      [{ termId: 1241, courseId: 2, code: 'cs136', name: 'x', prereqs: [] }],
+      1239,
+      null,
+    );
+    const planned = terms.find((t) => t.termId === 1241)!;
+    expect(planned.courses).toHaveLength(1);
+    expect(planned.courses[0].units).toBe(0.5);
+    expect(planned.taken).toBe(false);
+  });
+});
+
+describe('computePrereqWarnings', () => {
+  const term = (
+    termId: number,
+    courses: {
+      courseId: number;
+      code: string;
+      taken?: boolean;
+      prereqs?: { courseId: number; code: string; isCoreq: boolean }[];
+    }[],
+  ) => ({
+    termId,
+    level: '',
+    taken: courses.every((c) => c.taken ?? false),
+    courses: courses.map((c) => ({
+      courseId: c.courseId,
+      code: c.code,
+      name: c.code,
+      taken: c.taken ?? false,
+      units: 0.5,
+      prereqs: c.prereqs ?? [],
+    })),
+  });
+
+  it('warns only when no prereq alternative appears earlier', () => {
+    const math138 = { courseId: 10, code: 'math138', isCoreq: false };
+    const math137 = { courseId: 11, code: 'math137', isCoreq: false };
+    const terms = [
+      term(1239, [{ courseId: 11, code: 'math137', taken: true }]),
+      term(1241, [
+        // satisfied: math137 taken earlier
+        { courseId: 20, code: 'math239', prereqs: [math137, math138] },
+        // unsatisfied: needs math138
+        { courseId: 21, code: 'stat230', prereqs: [math138] },
+      ]),
+    ];
+    const warnings = computePrereqWarnings(terms);
+    expect(warnings.get('1241-20')).toBeUndefined();
+    expect(warnings.get('1241-21')).toBe('math138');
+  });
+
+  it('accepts coreqs in the same term', () => {
+    const coreq = { courseId: 30, code: 'math136', isCoreq: true };
+    const terms = [
+      term(1241, [
+        { courseId: 30, code: 'math136' },
+        { courseId: 31, code: 'stat231', prereqs: [coreq] },
+      ]),
+    ];
+    expect(computePrereqWarnings(terms).size).toBe(0);
+  });
+});
+
+describe('evaluateChecklist', () => {
+  it('matches any alternative and counts per category', () => {
+    const categories = evaluateChecklist(
+      [
+        {
+          category: 'Math',
+          courses: [
+            ['math135', 'math145'],
+            ['math137', 'math147'],
+          ],
+        },
+      ],
+      new Set(['math145']),
+    );
+    expect(categories[0].metCount).toBe(1);
+    expect(categories[0].items[0].matched).toBe('math145');
+    expect(categories[0].items[1].matched).toBeNull();
+  });
+});

--- a/src/pages/planPage/planner.ts
+++ b/src/pages/planPage/planner.ts
@@ -1,0 +1,201 @@
+import { PlannerDataQuery } from 'graphql/queries/planner/Planner';
+import { TranscriptGradeStore } from 'utils/Gpa';
+
+// ponytail: the DB stores no per-course units; 0.5 is true for nearly every
+// UW course. Transcript-parsed units override this for taken courses.
+export const DEFAULT_COURSE_UNITS = 0.5;
+
+export const LEVELS = ['1A', '1B', '2A', '2B', '3A', '3B', '4A', '4B'];
+
+// Next Fall/Winter term code (skips Spring, the usual co-op/off term):
+// Fall (x9) → Winter (+2), Winter (x1) → Fall (+8), Spring (x5) → Fall (+4).
+export const nextMajorTermCode = (code: number): number => {
+  const month = code % 10;
+  return month === 9 ? code + 2 : month === 1 ? code + 8 : code + 4;
+};
+
+export type PlannerCourse = {
+  courseId: number;
+  code: string;
+  name: string;
+  taken: boolean;
+  units: number;
+  // Structured prereqs, only populated for planned courses.
+  prereqs: { courseId: number; code: string; isCoreq: boolean }[];
+};
+
+export type PlannerTerm = {
+  termId: number;
+  level: string;
+  taken: boolean;
+  courses: PlannerCourse[];
+};
+
+export type PlanRow = {
+  termId: number;
+  courseId: number;
+  code: string;
+  name: string;
+  prereqs: PlannerCourse['prereqs'];
+};
+
+export const toPlanRows = (
+  planData: PlannerDataQuery['user_course_plan'],
+): PlanRow[] =>
+  planData
+    .filter((row) => row.course !== null)
+    .map((row) => ({
+      termId: row.term_id,
+      courseId: row.course_id,
+      code: row.course!.code,
+      name: row.course!.name,
+      prereqs: row
+        .course!.prerequisites.filter((p) => p.prerequisite !== null)
+        .map((p) => ({
+          courseId: p.prerequisite!.id,
+          code: p.prerequisite!.code,
+          isCoreq: p.is_corequisite === true,
+        })),
+    }));
+
+/*
+ * Terms shown on the planner: every transcript term (in order), then future
+ * Fall/Winter terms continuing the 1A–4B level sequence, plus any term the
+ * user has already planned courses into.
+ */
+export const buildTerms = (
+  takenData: PlannerDataQuery['user_course_taken'],
+  planRows: PlanRow[],
+  currentTermCode: number,
+  gradeStore: TranscriptGradeStore | null,
+): PlannerTerm[] => {
+  const takenByTerm = new Map<number, PlannerTerm>();
+  takenData.forEach((row) => {
+    if (!row.course) return;
+    let term = takenByTerm.get(row.term_id);
+    if (!term) {
+      term = {
+        termId: row.term_id,
+        level: row.level ?? '',
+        taken: true,
+        courses: [],
+      };
+      takenByTerm.set(row.term_id, term);
+    }
+    const parsedUnits = gradeStore?.[row.course.code]?.units ?? 0;
+    term.courses.push({
+      courseId: row.course.id,
+      code: row.course.code,
+      name: row.course.name,
+      taken: true,
+      units: parsedUnits > 0 ? parsedUnits : DEFAULT_COURSE_UNITS,
+      prereqs: [],
+    });
+  });
+
+  const terms = Array.from(takenByTerm.values()).sort(
+    (a, b) => a.termId - b.termId,
+  );
+  terms.forEach((term) =>
+    term.courses.sort((a, b) => a.code.localeCompare(b.code)),
+  );
+
+  // Continue the level sequence into future terms, up to 4B.
+  const lastTaken = terms[terms.length - 1];
+  const lastLevelIndex = lastTaken ? LEVELS.indexOf(lastTaken.level) : -1;
+  let termId = lastTaken
+    ? Math.max(nextMajorTermCode(lastTaken.termId), currentTermCode)
+    : currentTermCode;
+  for (let i = lastLevelIndex + 1; i < LEVELS.length; i++) {
+    terms.push({ termId, level: LEVELS[i], taken: false, courses: [] });
+    termId = nextMajorTermCode(termId);
+  }
+
+  // Terms planned outside the generated range (e.g. a Spring term) still show.
+  const known = new Set(terms.map((term) => term.termId));
+  planRows.forEach((row) => {
+    if (!known.has(row.termId)) {
+      known.add(row.termId);
+      terms.push({ termId: row.termId, level: '', taken: false, courses: [] });
+    }
+  });
+  terms.sort((a, b) => a.termId - b.termId);
+
+  // Slot planned courses into their terms.
+  const byTermId = new Map(terms.map((term) => [term.termId, term]));
+  planRows.forEach((row) => {
+    byTermId.get(row.termId)!.courses.push({
+      courseId: row.courseId,
+      code: row.code,
+      name: row.name,
+      taken: false,
+      units: DEFAULT_COURSE_UNITS,
+      prereqs: row.prereqs,
+    });
+  });
+
+  return terms;
+};
+
+/*
+ * "Needs X" prerequisite warnings, keyed by `${termId}-${courseId}`.
+ *
+ * ponytail: course_prerequisite is a flat list of every course mentioned in
+ * the prereq text (AND/OR mixed together), so we only warn when NONE of a
+ * course's prereqs appear in an earlier term (same term counts for coreqs).
+ * Real boolean prereq expressions would need importer support.
+ */
+export const computePrereqWarnings = (
+  terms: PlannerTerm[],
+): Map<string, string> => {
+  const warnings = new Map<string, string>();
+  const before = new Set<number>();
+
+  terms.forEach((term) => {
+    const inTerm = new Set(term.courses.map((course) => course.courseId));
+    term.courses.forEach((course) => {
+      if (course.taken || course.prereqs.length === 0) return;
+      const satisfied = course.prereqs.some((prereq) =>
+        prereq.isCoreq
+          ? before.has(prereq.courseId) || inTerm.has(prereq.courseId)
+          : before.has(prereq.courseId),
+      );
+      if (!satisfied) {
+        const needed =
+          course.prereqs.find((prereq) => !prereq.isCoreq) ?? course.prereqs[0];
+        warnings.set(`${term.termId}-${course.courseId}`, needed.code);
+      }
+    });
+    term.courses.forEach((course) => before.add(course.courseId));
+  });
+
+  return warnings;
+};
+
+export type ChecklistItemStatus = {
+  alternatives: string[];
+  // The course code from the plan/transcript satisfying this item, if any.
+  matched: string | null;
+};
+
+export type ChecklistCategoryStatus = {
+  category: string;
+  items: ChecklistItemStatus[];
+  metCount: number;
+};
+
+export const evaluateChecklist = (
+  requirements: PlannerDataQuery['checklist'][number]['requirements'],
+  haveCodes: Set<string>,
+): ChecklistCategoryStatus[] =>
+  requirements.map((group) => {
+    const items = group.courses.map((alternatives) => ({
+      alternatives,
+      matched: alternatives.find((code) => haveCodes.has(code)) ?? null,
+    }));
+    return {
+      category: group.category,
+      items,
+      metCount: items.filter((item) => item.matched !== null).length,
+    };
+  });

--- a/src/pages/planPage/planner.ts
+++ b/src/pages/planPage/planner.ts
@@ -42,21 +42,29 @@ export type PlanRow = {
 export const toPlanRows = (
   planData: PlannerDataQuery['user_course_plan'],
 ): PlanRow[] =>
-  planData
-    .filter((row) => row.course !== null)
-    .map((row) => ({
-      termId: row.term_id,
-      courseId: row.course_id,
-      code: row.course!.code,
-      name: row.course!.name,
-      prereqs: row
-        .course!.prerequisites.filter((p) => p.prerequisite !== null)
-        .map((p) => ({
-          courseId: p.prerequisite!.id,
-          code: p.prerequisite!.code,
-          isCoreq: p.is_corequisite === true,
-        })),
-    }));
+  planData.flatMap((row) => {
+    const { course } = row;
+    if (!course) return [];
+    return [
+      {
+        termId: row.term_id,
+        courseId: row.course_id,
+        code: course.code,
+        name: course.name,
+        prereqs: course.prerequisites.flatMap((p) =>
+          p.prerequisite
+            ? [
+                {
+                  courseId: p.prerequisite.id,
+                  code: p.prerequisite.code,
+                  isCoreq: p.is_corequisite === true,
+                },
+              ]
+            : [],
+        ),
+      },
+    ];
+  });
 
 /*
  * Terms shown on the planner: every transcript term (in order), then future
@@ -124,7 +132,9 @@ export const buildTerms = (
   // Slot planned courses into their terms.
   const byTermId = new Map(terms.map((term) => [term.termId, term]));
   planRows.forEach((row) => {
-    byTermId.get(row.termId)!.courses.push({
+    const term = byTermId.get(row.termId);
+    if (!term) return;
+    term.courses.push({
       courseId: row.courseId,
       code: row.code,
       name: row.name,

--- a/src/pages/swapPage/SwapCalendar.tsx
+++ b/src/pages/swapPage/SwapCalendar.tsx
@@ -23,6 +23,7 @@ import {
   CalendarEventVariant,
 } from 'components/calendar';
 import LastUpdatedSchedule from 'components/common/LastUpdatedSchedule';
+import CourseSearchDropdown from 'components/input/CourseSearchDropdown';
 import { GET_COURSE_FOR_SWAP } from 'graphql/queries/course/SwapCourse';
 import { cn } from 'lib/utils';
 import {
@@ -32,7 +33,6 @@ import {
   termCodeToDate,
 } from 'utils/Misc';
 
-import CourseSearchDropdown from './CourseSearchDropdown';
 import EnrolledCourseDropdown from './EnrolledCourseDropdown';
 import ScheduleSwapPanel, {
   ProfessorSwapStats,

--- a/src/pages/swapPage/SwapPage.tsx
+++ b/src/pages/swapPage/SwapPage.tsx
@@ -1,17 +1,17 @@
 import React, { useEffect } from 'react';
-import { Lock } from 'react-feather';
 import { Helmet } from 'react-helmet';
 import { useSelector } from 'react-redux';
 import { useQuery } from '@apollo/client';
 import { GetUserQuery, GetUserQueryVariables } from 'generated/graphql';
 
+import LoginPromptCard from 'components/auth/LoginPromptCard';
 import LoadingSpinner from 'components/display/LoadingSpinner';
+import PageOverlay from 'components/modal/PageOverlay';
 import ScheduleUploadModalContent from 'components/upload/ScheduleUploadModalContent';
-import { AUTH_MODAL, SWAP_TOUR_MODAL } from 'constants/Modal';
+import { SWAP_TOUR_MODAL } from 'constants/Modal';
 import { RootState } from 'data/reducers/RootReducer';
 import { GET_USER } from 'graphql/queries/user/User';
 import useModal from 'hooks/useModal';
-import { cn } from 'lib/utils';
 
 import DEMO_SCHEDULE from './demoSchedule';
 import SwapCalendar, { getDisplayedTermPresence } from './SwapCalendar';
@@ -102,48 +102,21 @@ const SwapPage = () => {
         schedule={isDemo ? DEMO_SCHEDULE : schedule}
         demoMode={isDemo}
       />
-      <div style={{ display: 'flex', justifyContent: 'center' }}>
-        <div
-          className={cn(
-            'fixed inset-0 z-10 box-border flex items-start justify-center overflow-y-auto bg-white/55 backdrop-blur [transition:opacity_0.4s_ease]',
-            !hasDisplayedTermClasses
-              ? 'pointer-events-auto opacity-100'
-              : 'pointer-events-none opacity-0',
-          )}
-        >
-          <div className="mt-[150px] flex justify-center">
-            {isLoggedIn ? (
-              <ScheduleUploadModalContent
-                onAfterUploadSuccess={() =>
-                  refetch({ id: Number(localStorage.getItem('user_id')) })
-                }
-                showSkipStepButton={false}
-              />
-            ) : (
-              <div className="flex max-w-[400px] flex-col items-center gap-3 rounded bg-white px-12 py-10 text-center shadow-[0_8px_32px_rgba(23,43,77,0.16)]">
-                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-light2 text-dark2">
-                  <Lock size={24} />
-                </div>
-                <h2 className="mb-0 mt-1 text-xl font-bold text-dark1">
-                  Upload your schedule to plan swaps
-                </h2>
-                <p className="m-0 text-sm leading-normal text-dark2">
-                  Log in and paste your courses from Quest to simulate section
-                  swaps and see which ones are possible. You make the actual
-                  swap in Quest.
-                </p>
-                <button
-                  className="mt-2 cursor-pointer rounded border-none bg-accent px-7 py-3 text-[15px] font-semibold text-dark1 transition-[filter] duration-100 ease-in hover:brightness-95"
-                  onClick={() => openModal(AUTH_MODAL)}
-                  type="button"
-                >
-                  Log in to continue
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      <PageOverlay visible={!hasDisplayedTermClasses}>
+        {isLoggedIn ? (
+          <ScheduleUploadModalContent
+            onAfterUploadSuccess={() =>
+              refetch({ id: Number(localStorage.getItem('user_id')) })
+            }
+            showSkipStepButton={false}
+          />
+        ) : (
+          <LoginPromptCard
+            title="Upload your schedule to plan swaps"
+            description="Log in and paste your courses from Quest to simulate section swaps and see which ones are possible. You make the actual swap in Quest."
+          />
+        )}
+      </PageOverlay>
     </div>
   );
 };

--- a/src/types/Api.tsx
+++ b/src/types/Api.tsx
@@ -89,6 +89,19 @@ export type ParseOnlyScheduleResponse = {
   Classes: ParseOnlyScheduleClass[];
 };
 
+export type TranscriptParsedCourse = {
+  code: string;
+  units: number;
+  grade: number | null;
+};
+
+export type TranscriptParsedTerm = {
+  term_id: number;
+  level: string;
+  courses: TranscriptParsedCourse[];
+};
+
 export type TranscriptParseResponse = {
   courses_imported: number;
+  terms: TranscriptParsedTerm[];
 };

--- a/src/utils/Gpa.ts
+++ b/src/utils/Gpa.ts
@@ -1,0 +1,115 @@
+import { TranscriptParseResponse } from 'types/Api';
+
+/*
+ * GPA calculation on the OMSAS 4.0 scale, credit-weighted by course units.
+ * Conversion table adapted from
+ * https://github.com/caseOfCamel/uwaterloo-gpa-calculator (whose transcript
+ * parsing is broken — we use grades parsed by our own backend instead).
+ *
+ * Grades come from the /parse/transcript response and are kept exclusively in
+ * localStorage: UW Flow never stores grades server-side (see privacy policy).
+ */
+
+export type TranscriptGradeEntry = {
+  units: number;
+  grade: number | null;
+  termId: number;
+};
+
+export type TranscriptGradeStore = {
+  // Keyed by course code in backend form, e.g. "cs135"
+  [code: string]: TranscriptGradeEntry;
+};
+
+const gradeStoreKey = (userId: number) => `transcript_grades_${userId}`;
+
+export const saveTranscriptGrades = (
+  userId: number,
+  response: TranscriptParseResponse,
+): void => {
+  if (!response.terms) {
+    return;
+  }
+
+  const store: TranscriptGradeStore = {};
+  response.terms.forEach((term) => {
+    term.courses.forEach((course) => {
+      store[course.code] = {
+        units: course.units,
+        grade: course.grade,
+        termId: term.term_id,
+      };
+    });
+  });
+  localStorage.setItem(gradeStoreKey(userId), JSON.stringify(store));
+};
+
+export const loadTranscriptGrades = (
+  userId: number,
+): TranscriptGradeStore | null => {
+  const raw = localStorage.getItem(gradeStoreKey(userId));
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as TranscriptGradeStore;
+  } catch {
+    return null;
+  }
+};
+
+/* OMSAS undergraduate percentage → 4.0 scale. */
+export const percentToGpa = (percent: number): number => {
+  if (percent >= 90) return 4.0;
+  if (percent >= 85) return 3.9;
+  if (percent >= 80) return 3.7;
+  if (percent >= 77) return 3.3;
+  if (percent >= 73) return 3.0;
+  if (percent >= 70) return 2.7;
+  if (percent >= 67) return 2.3;
+  if (percent >= 63) return 2.0;
+  if (percent >= 60) return 1.7;
+  if (percent >= 57) return 1.3;
+  if (percent >= 53) return 1.0;
+  if (percent >= 50) return 0.7;
+  return 0.0;
+};
+
+/*
+ * Credit-weighted cumulative GPA. Courses without a numeric grade (CR/NCR,
+ * current term) or without units are excluded, matching how Quest excludes
+ * them from "In GPA" totals. Returns null when nothing is gradable.
+ */
+export const computeGpa = (
+  entries: { units: number; grade: number | null }[],
+): number | null => {
+  let totalUnits = 0;
+  let totalPoints = 0;
+  entries.forEach(({ units, grade }) => {
+    if (grade === null || units <= 0) {
+      return;
+    }
+    totalUnits += units;
+    totalPoints += percentToGpa(grade) * units;
+  });
+  return totalUnits > 0 ? totalPoints / totalUnits : null;
+};
+
+/* Per-term GPA breakdown, ordered by term. */
+export const computeTermGpas = (
+  store: TranscriptGradeStore,
+): { termId: number; gpa: number }[] => {
+  const byTerm: { [termId: number]: TranscriptGradeEntry[] } = {};
+  Object.values(store).forEach((entry) => {
+    byTerm[entry.termId] = byTerm[entry.termId] || [];
+    byTerm[entry.termId].push(entry);
+  });
+
+  return Object.keys(byTerm)
+    .map(Number)
+    .sort((a, b) => a - b)
+    .map((termId) => ({ termId, gpa: computeGpa(byTerm[termId]) }))
+    .filter(
+      (term): term is { termId: number; gpa: number } => term.gpa !== null,
+    );
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -124,6 +124,8 @@ module.exports = {
         'dark-box': '0px 0px 10px #042049',
         'bottom-box':
           '0px 1px 3px rgba(236, 237, 237, 0.4), 0px 1px 3px rgba(142, 147, 148, 0.2)',
+        // Floating prompt cards (LoginPromptCard, upload modal content).
+        modal: '0 8px 32px rgba(23, 43, 77, 0.16)',
       },
       textShadow: {
         DEFAULT:


### PR DESCRIPTION
Frontend half of the course planner feature — requires backend PR UWFlow/uwflow#197 (transcript grades in the parse response + `user_course_plan`/`checklist` tables).

## What it does

New **/plan** page (linked from the navbar):

- **Term grid** populated from the transcript import: taken terms show a green "✓ taken" chip and per-term unit badges; future terms are generated by continuing the 1A–4B level sequence over Fall/Winter terms.
- **Plan future terms**: add courses via search (reuses `CourseSearchDropdown`, generalized and moved to `components/input/`), remove, and drag courses between terms (native HTML5 DnD, no new dependency). Persisted in `user_course_plan` with optimistic UI; moves run as a single-transaction Hasura mutation.
- **Prerequisite warnings** ("⚠ needs MATH 138") from structured `course_prerequisite` data — warns only when none of a course's prereqs appear in an earlier term, since the table flattens AND/OR.
- **GPA calculator** on the OMSAS 4.0 scale (conversion table adapted from caseOfCamel/uwaterloo-gpa-calculator, whose own parsing is broken), credit-weighted, cumulative + per-term. Grades come from the extended `/parse/transcript` response and live **only in localStorage** — never sent to or stored on the server.
- **Degree requirement checklists**: import any number of the backend-maintained checklists; per-category progress, "one of" alternatives, met items show the course that satisfied them.
- First visit without a transcript shows the existing transcript-upload flow (same overlay pattern as the swap page); logged-out visitors get the login lock card.

Tailwind-only styling using the design tokens from AGENTS.md; no new styled-components.

## Notes

- Types for the new GraphQL documents are hand-written in `graphql/queries/planner/Planner.tsx` since codegen needs a live Hasura with the new migration; swap for generated types on the next `bun run generate`.
- Deliberate simplifications are marked with `ponytail:` comments (default 0.5 units — the DB stores no per-course units; flat "one of" checklist requirements).

## Testing

- `bun run lint-nofix` clean, `tsc --noEmit` clean, production build passes.
- 9 new jest tests for the GPA table, term-sequence generation, prereq warnings, and checklist evaluation (`src/pages/planPage/__tests__/planner.test.ts`); full suite passes.
- Not yet exercised against a live backend (Docker stack was down) — needs a manual pass once UWFlow/uwflow#197 is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)