### PR TITLE
fix(upload): detect Course Selection paste and show a specific hint

### DIFF
--- a/src/components/upload/ScheduleUploadModalContent.tsx
+++ b/src/components/upload/ScheduleUploadModalContent.tsx
@@ -140,8 +140,17 @@ const ScheduleUploadModalContent = ({
 
       if ((response as ErrorResponse).error) {
         const errorRes = response as ErrorResponse;
+        // The Course Selection cart page contains a term header but no class
+        // numbers, so the backend reports it as an empty schedule. Detect it
+        // here (we have the pasted text) and give a more useful hint.
+        const isCourseSelection =
+          errorRes.error === 'empty_schedule' &&
+          /course selection/i.test(pastedSchedule);
         setUploadError(
-          SCHEDULE_ERRORS[errorRes.error] || SCHEDULE_ERRORS.default_schedule,
+          isCourseSelection
+            ? SCHEDULE_ERRORS.course_selection_schedule
+            : SCHEDULE_ERRORS[errorRes.error] ||
+                SCHEDULE_ERRORS.default_schedule,
         );
       } else {
         const scheduleRes = response as ScheduleParseResponse;

--- a/src/constants/Messages.tsx
+++ b/src/constants/Messages.tsx
@@ -34,6 +34,8 @@ export const TRANSCRIPT_ERRORS: MessageObject = {
 };
 
 export const SCHEDULE_ERRORS: MessageObject = {
+  course_selection_schedule:
+    'That looks like your Course Selection page – in Quest, go to Enroll → My Class Schedule and paste that instead.',
   empty_schedule:
     'Looks like that schedule is empty. Check for copy/paste errors, and try again.',
   old_schedule:


### PR DESCRIPTION
## Problem

Pasting Quest's **View My Course Selection** cart page into the schedule upload box shows the generic *"Looks like that schedule is empty"* error. The cart page has a term header (so the backend's term regex matches) but no 4–5 digit class numbers or rooms, so `/parse/schedule` returns `empty_schedule` and the user has no idea what went wrong.

## Fix

Client-side only — the frontend already has the pasted text. When the backend returns `empty_schedule` and the paste contains "Course Selection", show:

> That looks like your Course Selection page – in Quest, go to Enroll → My Class Schedule and paste that instead.

No backend change needed.

## Testing

- `bun run lint-nofix` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)