### PR TITLE
Track where signups come from in PostHog

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -14,7 +14,7 @@ Everything lives under [`src/lib/analytics/`](../src/lib/analytics):
 
 | File         | Responsibility                                               |
 |--------------|--------------------------------------------------------------|
-| `index.ts`   | `initAnalytics()` (init once near the app root), `capture(event, props)` (emit a custom event), `identify(userId)` (tie events to a user). All never throw, no-op when no key is configured, and `capture`/`identify` fire on the side (deferred a macrotask) so they never block UI. |
+| `index.ts`   | `initAnalytics()` (init once near the app root), `capture(event, props)` (emit a custom event), `identify(userId, props?, setOnceProps?)` (tie events to a user, optionally writing person properties). All never throw, no-op when no key is configured, and `capture`/`identify` fire on the side (deferred a macrotask) so they never block UI. |
 
 PostHog itself handles everything we used to hand-roll:
 
@@ -34,16 +34,52 @@ PostHog's pageview/session signals.
 
 ## Custom events
 
-We deliberately keep custom events few. Today there are two:
+We deliberately keep custom events few. Today there are four: three that make up
+the signup funnel, and one for reviews.
 
-### `account_created`
+### Signup attribution
 
-Fired once when a brand-new account is created (`is_new` from the auth
-response), from `AuthForm`'s `onAuthSuccess`.
+Three events share the same attribution properties, so a funnel can be broken
+down by any of them at every step:
 
 | Property | Type | Notes |
 |----------|------|-------|
-| `method` | `'email' \| 'google' \| 'facebook'` | Which signup path was used. |
+| `source` | `AuthSource` | Which piece of UI opened the auth form — see `AUTH_SOURCES` in [`src/constants/Analytics.tsx`](../src/constants/Analytics.tsx). Keep it a closed union; free text fragments the breakdown. |
+| `signup_page` | `string` | Route *pattern* the user was on, e.g. `/course/:courseCode`. Low cardinality — use this for breakdowns. |
+| `signup_path` | `string` | Concrete pathname, e.g. `/course/cs135`. Use for drill-down. |
+| `signup_referrer` | `string \| null` | `document.referrer` at the time the form appeared. |
+
+These are snapshotted in a ref when `AuthForm` **mounts**, not when the event
+fires. That matters: a successful signup redirects to `/welcome` before the
+deferred `capture` runs, so reading `location` at capture time would report
+`/welcome` as the origin of every signup.
+
+For **external** attribution (which site or campaign sent the user) you don't
+need any of this — PostHog already records `$referrer`, `$referring_domain`, and
+`$initial_utm_*` person properties. `signup_referrer` only covers a user landing
+directly on a page with the auth form.
+
+#### `auth_prompt_shown`
+
+Fired when `AuthForm` mounts. The funnel denominator — tells you which prompts
+convert, not just which ones produce signups.
+
+#### `signup_form_opened`
+
+Fired when the user switches the form from login to signup. The modal opens on
+login, so this is the clearest signup-intent signal available before the account
+exists.
+
+#### `account_created`
+
+Fired once when a brand-new account is created (`is_new` from the auth
+response), from `AuthForm`'s `onAuthSuccess`. Carries `method` (`'email' |
+'google' | 'facebook'`) on top of the attribution properties above.
+
+On signup we also write `initial_signup_method`, `initial_signup_source`, and
+`initial_signup_page` as `$set_once` person properties, so first-touch
+attribution survives later logins and can be used to segment cohorts long after
+the event.
 
 ### `review_posted`
 
@@ -71,6 +107,8 @@ import { initAnalytics, capture, identify } from 'lib/analytics';
 
 initAnalytics(); // once, near the app root (App.tsx)
 identify(userId); // after login/signup
+// $set_once person props — first touch wins, later logins don't overwrite
+identify(userId, undefined, { initial_signup_source: 'nav_profile' });
 capture('review_posted', { review_type: 'like', liked: 1 /* … */ });
 ```
 

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -19,9 +19,11 @@ export const PROFILE_PAGE_TESTER = pathToRegexp(PROFILE_PAGE_ROUTE);
 export const COURSE_PAGE_TESTER = pathToRegexp(COURSE_PAGE_ROUTE);
 export const EXPLORE_PAGE_TESTER = pathToRegexp(EXPLORE_PAGE_ROUTE);
 export const PROF_PAGE_TESTER = pathToRegexp(PROF_PAGE_ROUTE);
+export const SHORT_PROF_PAGE_TESTER = pathToRegexp(SHORT_PROF_PAGE_ROUTE);
 export const ABOUT_PAGE_TESTER = pathToRegexp(ABOUT_PAGE_ROUTE);
 export const PRIVACY_PAGE_TESTER = pathToRegexp(PRIVACY_PAGE_ROUTE);
 export const WELCOME_PAGE_TESTER = pathToRegexp(WELCOME_PAGE_ROUTE);
+export const SWAP_PAGE_TESTER = pathToRegexp(SWAP_PAGE_ROUTE);
 
 /* Page Testers */
 export const isOnLandingPageRoute = (location: Location) =>
@@ -47,6 +49,32 @@ export const isOnPrivacyPageRoute = (location: Location) =>
 
 export const isOnWelcomePageRoute = (location: Location) => {
   WELCOME_PAGE_TESTER.test(location.pathname);
+};
+
+/* Route Patterns */
+
+// Ordered most-specific first; `/` would otherwise never be reached.
+const ROUTE_PATTERNS: [RegExp, string][] = [
+  [COURSE_PAGE_TESTER, COURSE_PAGE_ROUTE],
+  [PROF_PAGE_TESTER, PROF_PAGE_ROUTE],
+  [SHORT_PROF_PAGE_TESTER, SHORT_PROF_PAGE_ROUTE],
+  [PROFILE_PAGE_TESTER, PROFILE_PAGE_ROUTE],
+  [EXPLORE_PAGE_TESTER, EXPLORE_PAGE_ROUTE],
+  [SWAP_PAGE_TESTER, SWAP_PAGE_ROUTE],
+  [ABOUT_PAGE_TESTER, ABOUT_PAGE_ROUTE],
+  [PRIVACY_PAGE_TESTER, PRIVACY_PAGE_ROUTE],
+  [WELCOME_PAGE_TESTER, WELCOME_PAGE_ROUTE],
+  [LANDING_PAGE_TESTER, LANDING_PAGE_ROUTE],
+];
+
+/**
+ * Collapse a concrete pathname to its route pattern — `/course/cs135` becomes
+ * `/course/:courseCode`. Analytics breaks down by this instead of the raw path
+ * so a handful of routes don't turn into thousands of distinct values.
+ */
+export const getRoutePattern = (pathname: string): string => {
+  const match = ROUTE_PATTERNS.find(([tester]) => tester.test(pathname));
+  return match ? match[1] : 'unknown';
 };
 
 /* Route Generators */

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -2,12 +2,15 @@ import React, {
   Dispatch,
   SetStateAction,
   SyntheticEvent,
+  useEffect,
+  useRef,
   useState,
 } from 'react';
 import { useDispatch } from 'react-redux';
 import { toast } from 'react-toastify';
-import { PRIVACY_PAGE_ROUTE } from 'Routes';
+import { getRoutePattern, PRIVACY_PAGE_ROUTE } from 'Routes';
 
+import { AuthSource } from 'constants/Analytics';
 import { AUTH_ERRORS, AUTH_SUCCESS, DEFAULT_ERROR } from 'constants/Messages';
 import { RESET_PASSWORD_MODAL } from 'constants/Modal';
 import { LOGGED_IN } from 'data/actions/AuthActions';
@@ -36,6 +39,8 @@ export type AuthMethod = 'email' | 'google' | 'facebook';
 type AuthFormProps = {
   onLoginComplete: () => void;
   onSignupComplete: () => void;
+  /** Which piece of UI opened this form — becomes the analytics attribution. */
+  source: AuthSource;
   margin?: string;
   closeAuthModal?: () => void;
 };
@@ -43,6 +48,7 @@ type AuthFormProps = {
 const AuthForm = ({
   onLoginComplete,
   onSignupComplete,
+  source,
   margin = '32px 0',
   closeAuthModal,
 }: AuthFormProps) => {
@@ -55,6 +61,23 @@ const AuthForm = ({
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+
+  // Snapshot where the user was when the form appeared. This must be read at
+  // mount, not at capture time: a successful signup redirects to /welcome
+  // before the deferred analytics call runs, so reading location later would
+  // report /welcome as the origin of every single signup.
+  const entry = useRef({
+    source,
+    signup_page: getRoutePattern(window.location.pathname),
+    signup_path: window.location.pathname,
+    signup_referrer: document.referrer || null,
+  });
+
+  // Denominator for the funnel: without it we'd know where signups come from
+  // but not which prompts actually convert.
+  useEffect(() => {
+    capture('auth_prompt_shown', entry.current);
+  }, []);
 
   const setJWT = (response: AuthResponse) => {
     localStorage.setItem('token', response.token);
@@ -73,9 +96,19 @@ const AuthForm = ({
     }
     // Analytics on the side — identify/capture defer themselves, so the login
     // toast and redirect above run first and are never blocked.
-    identify(response.user_id);
+    identify(
+      response.user_id,
+      undefined,
+      response.is_new
+        ? {
+            initial_signup_method: method,
+            initial_signup_source: entry.current.source,
+            initial_signup_page: entry.current.signup_page,
+          }
+        : undefined,
+    );
     if (response.is_new) {
-      capture('account_created', { method });
+      capture('account_created', { method, ...entry.current });
     }
   };
 
@@ -152,7 +185,14 @@ const AuthForm = ({
         <SwapModalWrapper>
           New to UW Flow?
           <SwapModalLink
-            onClick={() => setShowLoginForm(!showLoginForm)}
+            onClick={() => {
+              // The form opens on login, so switching to signup is the clearest
+              // signal of signup intent we get before the account exists.
+              if (showLoginForm) {
+                capture('signup_form_opened', entry.current);
+              }
+              setShowLoginForm(!showLoginForm);
+            }}
             onMouseDown={(e) => e.preventDefault()}
           >
             {showLoginForm ? 'Sign up' : 'Log in'}

--- a/src/components/auth/AuthModalContent.tsx
+++ b/src/components/auth/AuthModalContent.tsx
@@ -2,18 +2,23 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { WELCOME_PAGE_ROUTE } from 'Routes';
 
+import { AuthSource } from 'constants/Analytics';
+
 import AuthForm from './AuthForm';
 
 export type AuthModalContentProps = {
   onAfterLogin: () => void;
   onAfterSignup: () => void;
   onRequestClose: () => void;
+  /** Which piece of UI opened the modal — see `AUTH_SOURCES`. */
+  source: AuthSource;
 };
 
 const AuthModalContent = ({
   onAfterLogin,
   onAfterSignup,
   onRequestClose,
+  source,
 }: AuthModalContentProps) => {
   const history = useHistory();
 
@@ -25,6 +30,7 @@ const AuthModalContent = ({
   }
   return (
     <AuthForm
+      source={source}
       onLoginComplete={() => {
         onRequestClose();
         if (onAfterLogin) {

--- a/src/components/display/Review.tsx
+++ b/src/components/display/Review.tsx
@@ -6,6 +6,7 @@ import moment from 'moment/moment';
 import { getProfPageRoute } from 'Routes';
 import { useTheme } from 'styled-components';
 
+import { AUTH_SOURCES } from 'constants/Analytics';
 import { AUTH_MODAL } from 'constants/Modal';
 import { getIsBrowserDesktop, RootState } from 'data/reducers/RootReducer';
 import {
@@ -122,7 +123,7 @@ const Review = ({ review, isCourseReview }: ReviewProps) => {
 
   const onClickUpvote = () => {
     if (!isLoggedIn) {
-      openModal(AUTH_MODAL);
+      openModal(AUTH_MODAL, { source: AUTH_SOURCES.REVIEW_UPVOTE });
       return;
     }
 

--- a/src/components/input/LikeCourseToggle.tsx
+++ b/src/components/input/LikeCourseToggle.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { useMutation } from '@apollo/client';
 import { useTheme } from 'styled-components';
 
+import { AUTH_SOURCES } from 'constants/Analytics';
 import { AUTH_MODAL } from 'constants/Modal';
 import { RootState } from 'data/reducers/RootReducer';
 import { UPSERT_LIKED_REVIEW } from 'graphql/mutations/Review';
@@ -77,7 +78,7 @@ const LikeCourseToggle = ({
 
   const toggleOnClick = (targetState: number) => {
     if (!isLoggedIn) {
-      openModal(AUTH_MODAL);
+      openModal(AUTH_MODAL, { source: AUTH_SOURCES.LIKE_COURSE });
       return;
     }
 

--- a/src/components/input/ShortlistStar.tsx
+++ b/src/components/input/ShortlistStar.tsx
@@ -5,6 +5,7 @@ import { useMutation } from '@apollo/client';
 import { useTheme } from 'styled-components';
 
 import Tooltip from 'components/display/Tooltip';
+import { AUTH_SOURCES } from 'constants/Analytics';
 import { SHORTLIST_ERROR } from 'constants/Messages';
 import { AUTH_MODAL } from 'constants/Modal';
 import { RootState } from 'data/reducers/RootReducer';
@@ -65,7 +66,7 @@ const ShortlistStar = ({
 
   const onStarClicked = () => {
     if (!isLoggedIn) {
-      openModal(AUTH_MODAL);
+      openModal(AUTH_MODAL, { source: AUTH_SOURCES.SHORTLIST_STAR });
       return;
     }
 

--- a/src/components/navigation/ProfileDropdown.tsx
+++ b/src/components/navigation/ProfileDropdown.tsx
@@ -12,6 +12,7 @@ import {
 import { useTheme } from 'styled-components';
 
 import DropdownList from 'components/input/DropdownList';
+import { AUTH_SOURCES } from 'constants/Analytics';
 import { AUTH_MODAL } from 'constants/Modal';
 import { RootState } from 'data/reducers/RootReducer';
 import { GET_USER } from 'graphql/queries/user/User';
@@ -72,7 +73,9 @@ const ProfileDropdown = () => {
   });
 
   const handleProfileButtonClick = () =>
-    isLoggedIn ? history.push(PROFILE_PAGE_ROUTE) : openModal(AUTH_MODAL);
+    isLoggedIn
+      ? history.push(PROFILE_PAGE_ROUTE)
+      : openModal(AUTH_MODAL, { source: AUTH_SOURCES.NAV_PROFILE });
 
   return (
     <ProfileDropdownWrapper>

--- a/src/constants/Analytics.tsx
+++ b/src/constants/Analytics.tsx
@@ -1,0 +1,28 @@
+/**
+ * Analytics vocabulary shared by call sites and the events they emit.
+ *
+ * `AuthSource` identifies *which* piece of UI put the auth form in front of the
+ * user. Keep it a closed union: these values become PostHog breakdown keys, so
+ * free-text drift would fragment the funnel.
+ */
+
+export const AUTH_SOURCES = {
+  /** The always-visible auth form on the desktop landing page. */
+  LANDING_FORM: 'landing_form',
+  /** Profile icon in the nav bar — login intent as often as signup. */
+  NAV_PROFILE: 'nav_profile',
+  /** "Log in to continue" card gating the swap planner. */
+  SWAP_PAGE_PROMPT: 'swap_page_prompt',
+  /** Thumbs up/down on a course. */
+  LIKE_COURSE: 'like_course',
+  /** Shortlist star on a course. */
+  SHORTLIST_STAR: 'shortlist_star',
+  /** Upvoting someone else's review. */
+  REVIEW_UPVOTE: 'review_upvote',
+  /** "Write a review" on a course page. */
+  WRITE_REVIEW: 'write_review',
+  /** Section notification bell on a course page. */
+  SCHEDULE_NOTIFICATION: 'schedule_notification',
+} as const;
+
+export type AuthSource = (typeof AUTH_SOURCES)[keyof typeof AUTH_SOURCES];

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -83,10 +83,19 @@ export const capture = (
  * Tie subsequent events to a logged-in user. Call after login/signup so events
  * (and the session that led to them) attach to the user's PostHog person.
  * Fires on the side, preserving call order (identify before any later capture).
+ *
+ * `properties` overwrite on every call; `setOnceProperties` are written only the
+ * first time they're seen for a person, which is what first-touch signup
+ * attribution wants — a later login must not overwrite how they originally
+ * arrived.
  */
-export const identify = (userId: string | number): void => {
+export const identify = (
+  userId: string | number,
+  properties?: Record<string, unknown>,
+  setOnceProperties?: Record<string, unknown>,
+): void => {
   if (!enabled || userId === null || userId === undefined) {
     return;
   }
-  onSide(() => posthog.identify(String(userId)));
+  onSide(() => posthog.identify(String(userId), properties, setOnceProperties));
 };

--- a/src/pages/coursePage/CoursePage.tsx
+++ b/src/pages/coursePage/CoursePage.tsx
@@ -18,6 +18,7 @@ import {
 import LoadingSpinner from 'components/display/LoadingSpinner';
 import Button from 'components/input/Button';
 import LikeCourseToggle from 'components/input/LikeCourseToggle';
+import { AUTH_SOURCES } from 'constants/Analytics';
 import { DEFAULT_ERROR, NOT_FOUND } from 'constants/Messages';
 import { AUTH_MODAL, COURSE_REVIEW_COURSE_MODAL } from 'constants/Modal';
 import { getIsBrowserDesktop, RootState } from 'data/reducers/RootReducer';
@@ -99,7 +100,7 @@ const CoursePageContent = ({
           courseReviews: [{ course, review: userReview }],
           onCancel: () => closeModal(COURSE_REVIEW_COURSE_MODAL),
         })
-      : openModal(AUTH_MODAL);
+      : openModal(AUTH_MODAL, { source: AUTH_SOURCES.WRITE_REVIEW });
 
   const Schedule = (
     <CourseSchedule

--- a/src/pages/coursePage/ScheduleNotificationBell.tsx
+++ b/src/pages/coursePage/ScheduleNotificationBell.tsx
@@ -5,6 +5,7 @@ import { toast } from 'react-toastify';
 import { useMutation } from '@apollo/client';
 
 import Tooltip from 'components/display/Tooltip';
+import { AUTH_SOURCES } from 'constants/Analytics';
 import {
   SUBSCRIPTION_ERROR,
   SUBSCRIPTION_SUCCESS,
@@ -72,7 +73,7 @@ const ScheduleNotificationBell = ({
 
   const toggleOnClick = () => {
     if (!isLoggedIn) {
-      openModal(AUTH_MODAL);
+      openModal(AUTH_MODAL, { source: AUTH_SOURCES.SCHEDULE_NOTIFICATION });
       return;
     }
 

--- a/src/pages/landingPage/LandingPage.tsx
+++ b/src/pages/landingPage/LandingPage.tsx
@@ -6,6 +6,7 @@ import { PROFILE_PAGE_ROUTE, WELCOME_PAGE_ROUTE } from 'Routes';
 import AuthForm from 'components/auth/AuthForm';
 import ProfileDropdown from 'components/navigation/ProfileDropdown';
 import SearchBar from 'components/navigation/SearchBar';
+import { AUTH_SOURCES } from 'constants/Analytics';
 import { getIsBrowserDesktop, RootState } from 'data/reducers/RootReducer';
 
 import {
@@ -49,6 +50,7 @@ const LandingPage = () => {
           {isDesktop && !isLoggedIn && (
             <AuthContent>
               <AuthForm
+                source={AUTH_SOURCES.LANDING_FORM}
                 margin="auto 0"
                 onLoginComplete={() => history.push(PROFILE_PAGE_ROUTE)}
                 onSignupComplete={() =>

--- a/src/pages/swapPage/SwapPage.tsx
+++ b/src/pages/swapPage/SwapPage.tsx
@@ -7,6 +7,7 @@ import { GetUserQuery, GetUserQueryVariables } from 'generated/graphql';
 
 import LoadingSpinner from 'components/display/LoadingSpinner';
 import ScheduleUploadModalContent from 'components/upload/ScheduleUploadModalContent';
+import { AUTH_SOURCES } from 'constants/Analytics';
 import { AUTH_MODAL, SWAP_TOUR_MODAL } from 'constants/Modal';
 import { RootState } from 'data/reducers/RootReducer';
 import { GET_USER } from 'graphql/queries/user/User';
@@ -134,7 +135,11 @@ const SwapPage = () => {
                 </p>
                 <button
                   className="mt-2 cursor-pointer rounded border-none bg-accent px-7 py-3 text-[15px] font-semibold text-dark1 transition-[filter] duration-100 ease-in hover:brightness-95"
-                  onClick={() => openModal(AUTH_MODAL)}
+                  onClick={() =>
+                    openModal(AUTH_MODAL, {
+                      source: AUTH_SOURCES.SWAP_PAGE_PROMPT,
+                    })
+                  }
                   type="button"
                 >
                   Log in to continue


### PR DESCRIPTION
## Why

`account_created` recorded only `method` (email/google/facebook), so we could see *that* signups happened but not *where* they came from. Eight different places in the product put the auth form in front of a user and none of them identified themselves, so there was no way to tell which prompts drive accounts.

## What

**A closed `AuthSource` union** (`src/constants/Analytics.tsx`) threaded through every entry point:

| Source | Entry point |
|---|---|
| `landing_form` | Inline form on the desktop landing page |
| `nav_profile` | Profile icon in the nav bar |
| `swap_page_prompt` | "Log in to continue" card on the swap page |
| `like_course` | Thumbs up/down on a course |
| `shortlist_star` | Shortlist star |
| `review_upvote` | Upvoting a review |
| `write_review` | "Write a review" on a course page |
| `schedule_notification` | Section notification bell |

**Three events sharing one attribution shape** — `source`, `signup_page`, `signup_path`, `signup_referrer` — so a funnel can be broken down by source at every step:

- `auth_prompt_shown` — fired on `AuthForm` mount. The denominator; without it we'd know where signups come from but not which prompts *convert*.
- `signup_form_opened` — fired when the user switches the form from login to signup. The modal opens on the login form, so this is the clearest signup-intent signal available before an account exists.
- `account_created` — unchanged trigger, now carrying the attribution properties alongside `method`.

**Person properties**: `initial_signup_method` / `initial_signup_source` / `initial_signup_page` are written via `$set_once`, so first-touch attribution survives later logins and can segment cohorts long after the event.

## Two details worth a look

**The location snapshot is taken at mount, not at capture time.** This is the bug this PR would otherwise have shipped with: `capture` defers by a macrotask, and `onSignupComplete()` runs `history.push(WELCOME_PAGE_ROUTE)` first — so reading `location` inside the capture would report `/welcome` as the origin of every single signup. `AuthForm` snapshots into a ref on mount instead.

**`signup_page` is the route pattern, not the path.** New `getRoutePattern()` in `Routes.tsx` collapses `/course/cs135` to `/course/:courseCode`, so breakdowns stay at a handful of values instead of thousands. The raw path still ships as `signup_path` for drill-down.

## Notes

- The landing page renders `AuthForm` unconditionally for logged-out desktop users, so `auth_prompt_shown` fires on every such landing-page visit. That's semantically correct — the prompt *is* shown — but it makes `landing_form` a much larger funnel top than the modal sources. Compare conversion rates, not raw counts, across sources.
- No code needed for *external* attribution (which site or campaign sent someone): PostHog already records `$referrer`, `$referring_domain`, and `$initial_utm_*`. `signup_referrer` only covers landing directly on a page that has the form.
- `respect_dnt: true` is unchanged, so DNT users stay invisible and these numbers remain a lower bound.
- Branched from `main`, so the `/plan` page's `LoginPromptCard` (currently on `feat/course-planner`) has no source yet — it needs `AUTH_SOURCES.PLAN_PAGE_PROMPT` added when that branch lands.

## Testing

`bun run lint-nofix` clean, `bunx tsc --noEmit` clean, `bun run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)