### PR TITLE
feat(swap): persist the swap sandbox in localStorage

### DIFF
--- a/src/components/banner/AnnouncementBanner.tsx
+++ b/src/components/banner/AnnouncementBanner.tsx
@@ -29,14 +29,14 @@ const AnnouncementBanner = () => {
       <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 bg-accent px-6 py-3">
         <Repeat aria-hidden="true" className="shrink-0 text-dark1" size={20} />
         <div className="min-w-0 text-md text-dark1">
-          <strong>Introducing Class Swapper.</strong> No more Quest tab swapping
-          to figure out your ideal schedule.
+          <strong>Introducing the Class Swap Sandbox.</strong> No more Quest tab
+          swapping to figure out your ideal schedule.
         </div>
         <Link
           className="flex shrink-0 items-center gap-2 rounded-lg bg-dark1 px-5 py-2.5 text-sm font-semibold text-white no-underline transition-colors hover:bg-primaryExtraDark hover:text-white"
           to={SWAP_PAGE_ROUTE}
         >
-          Start swapping
+          Open the sandbox
           <ArrowRight aria-hidden="true" size={16} />
         </Link>
         <button

--- a/src/components/navigation/ProfileDropdown.tsx
+++ b/src/components/navigation/ProfileDropdown.tsx
@@ -86,7 +86,7 @@ const ProfileDropdown = () => {
             width={150}
             color={isLanding ? theme.white : theme.dark2}
             itemColor={theme.dark1}
-            options={['View profile', 'Swap Class', 'Log out']}
+            options={['View profile', 'Swap Sandbox', 'Log out']}
             onChange={(idx) => {
               if (idx === 0) {
                 handleProfileButtonClick();

--- a/src/components/tour/SwapTourModalContent.tsx
+++ b/src/components/tour/SwapTourModalContent.tsx
@@ -11,7 +11,7 @@ const STEPS = [
   {
     heading: 'Plan swaps in a sandbox',
     body:
-      'This tool simulates section swaps so you can check whether one is ' +
+      'This sandbox simulates section swaps so you can check whether one is ' +
       'possible before touching Quest — it never changes your enrollment.',
   },
   {
@@ -19,7 +19,8 @@ const STEPS = [
     body:
       'Click any class to see every other section — meeting times, rooms, ' +
       'professor ratings, and open seats. Conflicts and full sections are ' +
-      'flagged so you know what would actually work.',
+      'flagged so you know what would actually work. Your sandbox is saved ' +
+      'in this browser, so it survives a refresh until you reset it.',
   },
   {
     heading: 'Then make the swap in Quest',
@@ -60,7 +61,7 @@ const MiniBlock = ({
 );
 
 /**
- * First-visit tour for the section-swap page. The host page persists
+ * First-visit tour for the section-swap sandbox. The host page persists
  * dismissal (Skip, X, or finishing the last step) via its onRequestClose
  * override, so the tour only ever shows once.
  */
@@ -122,7 +123,7 @@ const SwapTourModalContent = ({
       {/* Copy + controls */}
       <div className="flex flex-col px-lg pb-lg pt-lg">
         <div className="mb-sm flex items-center gap-sm text-xs font-bold uppercase tracking-[0.08em] text-accentDark">
-          <Repeat size={13} /> Swap Class
+          <Repeat size={13} /> Swap Class Sandbox
         </div>
         <h2 className="mb-sm text-2xl font-bold text-dark1">
           {STEPS[step].heading}

--- a/src/pages/swapPage/ScheduleSwapPanel.tsx
+++ b/src/pages/swapPage/ScheduleSwapPanel.tsx
@@ -212,7 +212,7 @@ const EmptyState = () => (
     <div className="text-sm font-semibold text-dark1">Select a course</div>
     <div className="mt-2 max-w-[260px] text-sm leading-5 text-dark3">
       Click a class in your schedule to see other sections, prof ratings, and
-      swap options.
+      swap options to try in your sandbox.
     </div>
   </div>
 );
@@ -316,7 +316,7 @@ const ScheduleSectionRow = ({
             type="button"
             variant="accent"
           >
-            Choose section
+            Try in sandbox
           </Button>
         )}
       </div>

--- a/src/pages/swapPage/SwapCalendar.tsx
+++ b/src/pages/swapPage/SwapCalendar.tsx
@@ -34,6 +34,13 @@ import {
 
 import CourseSearchDropdown from './CourseSearchDropdown';
 import EnrolledCourseDropdown from './EnrolledCourseDropdown';
+import {
+  clearSwapSandbox,
+  isSandboxModified,
+  loadSwapSandbox,
+  SandboxByTerm,
+  saveSwapSandbox,
+} from './sandboxStorage';
 import ScheduleSwapPanel, {
   ProfessorSwapStats,
   SwapCandidateCourse,
@@ -250,10 +257,18 @@ type SwapCalendarProps = {
   schedule: UserScheduleFragment['schedule'];
   /** Renders a non-interactive sample schedule (logged-out lock state). */
   demoMode?: boolean;
+  /** Owner of the sandbox in localStorage; null disables persistence. */
+  userId?: number | null;
 };
 
-const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
+const SwapCalendar = ({
+  schedule,
+  demoMode = false,
+  userId = null,
+}: SwapCalendarProps) => {
   const termMap = useMemo(() => groupScheduleByTerm(schedule), [schedule]);
+  // Demo schedules are a marketing prop, not the visitor's own — never stored.
+  const persistUserId = demoMode ? null : userId;
 
   const thisTermCode = getCurrentTermCode();
   const nextTermCode = getNextTermCode();
@@ -279,12 +294,20 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
   const [isSwapDropdownOpen, setIsSwapDropdownOpen] = useState(false);
   // The left selector lists courses the user is already enrolled in.
   const [isCourseDropdownOpen, setIsCourseDropdownOpen] = useState(false);
-  // Temporary client-side section swaps, keyed by term label. A swap replaces
-  // the matching schedule entry in React state only — refreshing the page
-  // restores the original schedule (no persistence, no mutations).
-  const [overriddenByTerm, setOverriddenByTerm] = useState<
-    Record<string, UserScheduleFragment['schedule']>
-  >({});
+  // The sandbox: client-side section swaps keyed by term label. A swap replaces
+  // the matching schedule entry here only — it never mutates the user's real
+  // enrollment. The sandbox is mirrored into localStorage so a refresh keeps it;
+  // "Reset sandbox" is the only way back to the real schedule.
+  const [sandboxByTerm, setSandboxByTerm] = useState<SandboxByTerm>(() =>
+    persistUserId === null ? {} : loadSwapSandbox(persistUserId, termMap),
+  );
+
+  // Mirror every sandbox change back to storage (and clear it once the sandbox
+  // matches the real schedule again).
+  useEffect(() => {
+    if (persistUserId === null) return;
+    saveSwapSandbox(persistUserId, sandboxByTerm, termMap);
+  }, [persistUserId, sandboxByTerm, termMap]);
 
   useEffect(() => {
     setSelectedSwapCourseCode(null);
@@ -295,10 +318,10 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
 
   const selectedTermCode =
     selectedTerm === nextTermLabel ? nextTermCode : thisTermCode;
-  // Effective schedule for the term: temporary swaps take precedence.
+  // Effective schedule for the term: sandboxed swaps take precedence.
   const termSections = useMemo(
-    () => overriddenByTerm[selectedTerm] ?? termMap[selectedTerm] ?? [],
-    [overriddenByTerm, termMap, selectedTerm],
+    () => sandboxByTerm[selectedTerm] ?? termMap[selectedTerm] ?? [],
+    [sandboxByTerm, termMap, selectedTerm],
   );
 
   // Distinct courses in the user's schedule for this term, for the left
@@ -466,7 +489,8 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
     [],
   );
 
-  // Term overrides persist while the page lives — only a refresh resets them.
+  // The sandbox spans both terms and outlives a refresh — switching terms only
+  // clears the current selection.
   const handleTermChange = useCallback((termId: number) => {
     setSelectedTerm(termCodeToDate(termId));
     setSelection(null);
@@ -495,9 +519,9 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
     [termSections],
   );
 
-  // Temporarily swap a section into the schedule (React state only). The new
-  // section replaces the entry matching the selected course + section type
-  // (LEC↔LEC, TUT↔TUT) — the panel only offers same-type candidates.
+  // Swap a section into the sandbox schedule. The new section replaces the
+  // entry matching the selected course + section type (LEC↔LEC, TUT↔TUT) — the
+  // panel only offers same-type candidates.
   const handleSwitchSection = useCallback(
     (sectionId: number) => {
       const newSection = swapSections.find((s) => s.id === sectionId);
@@ -516,7 +540,7 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
         newSection,
         base[replaceIndex].user_id,
       );
-      setOverriddenByTerm((prev) => ({ ...prev, [selectedTerm]: next }));
+      setSandboxByTerm((prev) => ({ ...prev, [selectedTerm]: next }));
       setHoveredSection(null);
       if (newSection.course.code !== selection.courseCode) {
         // Follow the swapped-in course (keeping the selected section type);
@@ -559,7 +583,20 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
     { id: nextTermCode, label: nextTermLabel },
   ];
   const swapTargetCode = selectedSwapCourseCode ?? selectedCourseCode;
-  const hasSwaps = Object.keys(overriddenByTerm).length > 0;
+  // Only a sandbox that actually differs from the real schedule offers a reset:
+  // swapping a section and swapping it back leaves nothing to undo.
+  const isModified = isSandboxModified(sandboxByTerm, termMap);
+
+  // Discard the sandbox — in memory and in storage — and go back to the user's
+  // real schedule.
+  const handleResetSandbox = useCallback(() => {
+    setSandboxByTerm({});
+    // A cross-course swap can leave the selection pointing at a course the real
+    // schedule doesn't have, so drop it along with the sandbox.
+    setSelection(null);
+    setHoveredSection(null);
+    if (persistUserId !== null) clearSwapSandbox(persistUserId);
+  }, [persistUserId]);
 
   return (
     <div className="relative z-0 w-screen animate-fade-in">
@@ -568,7 +605,7 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
           <div className="min-w-0">
             <div className="flex items-center gap-2">
               <h1 className="m-0 font-anderson text-4xl font-extrabold text-dark1 tabletDown:text-3xl">
-                Swap Class
+                Swap Class Sandbox
               </h1>
               <span className="rounded bg-accent px-1.5 py-0.5 text-xs font-extrabold text-dark1">
                 NEW
@@ -576,7 +613,8 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
             </div>
             <p className="mb-0 mt-1 font-inter text-md font-regular text-dark2">
               Click any class to compare sections and check if a swap is
-              possible — you make the actual change in Quest.
+              possible. Your sandbox is saved in this browser — you make the
+              actual change in Quest.
             </p>
           </div>
           <div className="inline-flex shrink-0 rounded border border-solid border-light3 bg-white p-1">
@@ -670,18 +708,18 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
                   Select a class on your schedule
                 </span>
               )}
-              {hasSwaps && (
-                // Swaps live only in React state, so a refresh restores the
-                // real schedule.
+              {isModified && (
+                // The sandbox survives refreshes, so this is the only way back
+                // to the real schedule.
                 <button
-                  aria-label="Reset swapped sections"
-                  title="Reset swapped sections"
+                  aria-label="Reset sandbox to your real schedule"
+                  title="Reset sandbox to your real schedule"
                   className="ml-auto flex shrink-0 cursor-pointer items-center gap-1 border-none bg-transparent p-0 font-inter text-xs font-semibold text-dark2 outline-none transition-colors hover:text-dark1"
-                  onClick={() => window.location.reload()}
+                  onClick={handleResetSandbox}
                   type="button"
                 >
                   <RotateCcw aria-hidden="true" size={14} />
-                  Reset
+                  Reset sandbox
                 </button>
               )}
             </div>

--- a/src/pages/swapPage/SwapPage.tsx
+++ b/src/pages/swapPage/SwapPage.tsx
@@ -80,7 +80,7 @@ const SwapPage = () => {
     return (
       <div className={swapPageWrapperClasses}>
         <Helmet>
-          <title>Swap Class - UW Flow</title>
+          <title>Swap Class Sandbox - UW Flow</title>
         </Helmet>
         <LoadingSpinner />
       </div>
@@ -90,17 +90,18 @@ const SwapPage = () => {
   return (
     <div className={swapPageWrapperClasses}>
       <Helmet>
-        <title>Swap Class - UW Flow</title>
+        <title>Swap Class Sandbox - UW Flow</title>
         {hasDisplayedTermClasses && (
           <meta
             name="description"
-            content="Simulate UW course section swaps to check they're possible before making the change in Quest."
+            content="A sandbox for UW course section swaps: simulate them to check they're possible before making the change in Quest."
           />
         )}
       </Helmet>
       <SwapCalendar
         schedule={isDemo ? DEMO_SCHEDULE : schedule}
         demoMode={isDemo}
+        userId={user?.id ?? null}
       />
       <div style={{ display: 'flex', justifyContent: 'center' }}>
         <div
@@ -125,12 +126,12 @@ const SwapPage = () => {
                   <Lock size={24} />
                 </div>
                 <h2 className="mb-0 mt-1 text-xl font-bold text-dark1">
-                  Upload your schedule to plan swaps
+                  Upload your schedule to open your sandbox
                 </h2>
                 <p className="m-0 text-sm leading-normal text-dark2">
                   Log in and paste your courses from Quest to simulate section
-                  swaps and see which ones are possible. You make the actual
-                  swap in Quest.
+                  swaps in a sandbox and see which ones are possible. You make
+                  the actual swap in Quest.
                 </p>
                 <button
                   className="mt-2 cursor-pointer rounded border-none bg-accent px-7 py-3 text-[15px] font-semibold text-dark1 transition-[filter] duration-100 ease-in hover:brightness-95"

--- a/src/pages/swapPage/__tests__/sandboxStorage.test.ts
+++ b/src/pages/swapPage/__tests__/sandboxStorage.test.ts
@@ -1,0 +1,69 @@
+import {
+  clearSwapSandbox,
+  isSandboxModified,
+  loadSwapSandbox,
+  SandboxByTerm,
+  SandboxScheduleEntry,
+  saveSwapSandbox,
+} from '../sandboxStorage';
+
+const USER_ID = 1;
+const TERM = 'Fall 2025';
+
+// Only the section id matters to the storage layer.
+const entry = (id: number) =>
+  ({ user_id: USER_ID, section: { id } } as unknown as SandboxScheduleEntry);
+
+const base: SandboxByTerm = { [TERM]: [entry(1), entry(2)] };
+const swapped: SandboxByTerm = { [TERM]: [entry(9), entry(2)] };
+
+beforeEach(() => localStorage.clear());
+
+describe('swap sandbox storage', () => {
+  it('round-trips a modified sandbox', () => {
+    saveSwapSandbox(USER_ID, swapped, base);
+    expect(loadSwapSandbox(USER_ID, base)).toEqual(swapped);
+  });
+
+  it('stores nothing once the sandbox matches the real schedule', () => {
+    saveSwapSandbox(USER_ID, swapped, base);
+    // Order is irrelevant: the same sections mean nothing was swapped.
+    saveSwapSandbox(USER_ID, { [TERM]: [entry(2), entry(1)] }, base);
+    expect(loadSwapSandbox(USER_ID, base)).toEqual({});
+  });
+
+  it('drops a sandbox branched off a schedule that has since changed', () => {
+    saveSwapSandbox(USER_ID, swapped, base);
+    const reimported: SandboxByTerm = { [TERM]: [entry(3), entry(4)] };
+    expect(loadSwapSandbox(USER_ID, reimported)).toEqual({});
+  });
+
+  it('keeps sandboxes separate per user', () => {
+    saveSwapSandbox(USER_ID, swapped, base);
+    expect(loadSwapSandbox(USER_ID + 1, base)).toEqual({});
+  });
+
+  it('ignores unparseable stored data', () => {
+    localStorage.setItem(`swap_sandbox_${USER_ID}`, 'not json');
+    expect(loadSwapSandbox(USER_ID, base)).toEqual({});
+  });
+
+  it('clears the sandbox', () => {
+    saveSwapSandbox(USER_ID, swapped, base);
+    clearSwapSandbox(USER_ID);
+    expect(loadSwapSandbox(USER_ID, base)).toEqual({});
+  });
+});
+
+describe('isSandboxModified', () => {
+  it('is false for an empty or unchanged sandbox', () => {
+    expect(isSandboxModified({}, base)).toBe(false);
+    expect(isSandboxModified({ [TERM]: [entry(2), entry(1)] }, base)).toBe(
+      false,
+    );
+  });
+
+  it('is true once a section differs from the real schedule', () => {
+    expect(isSandboxModified(swapped, base)).toBe(true);
+  });
+});

--- a/src/pages/swapPage/sandboxStorage.ts
+++ b/src/pages/swapPage/sandboxStorage.ts
@@ -1,0 +1,122 @@
+import { UserScheduleFragment } from 'generated/graphql';
+
+/**
+ * Local persistence for the swap sandbox.
+ *
+ * The sandbox is a client-side simulation — swapping a section never touches
+ * the user's real enrollment — but losing a half-planned schedule to a refresh
+ * is annoying, so the sandboxed schedule is mirrored into localStorage. Nothing
+ * is sent to the server.
+ *
+ * A stored sandbox is branched off the real schedule as it looked when the swap
+ * was made. If that schedule later changes (e.g. a fresh Quest import), the
+ * branch is discarded rather than replayed on top of a different base.
+ */
+
+export type SandboxScheduleEntry = UserScheduleFragment['schedule'][number];
+
+/** Sandboxed schedules keyed by term label, e.g. "Fall 2025". */
+export type SandboxByTerm = { [term: string]: SandboxScheduleEntry[] };
+
+const SANDBOX_VERSION = 1;
+
+const sandboxKey = (userId: number) => `swap_sandbox_${userId}`;
+
+type StoredTerm = {
+  /** Fingerprint of the real schedule this sandbox was branched from. */
+  base: string;
+  sections: SandboxScheduleEntry[];
+};
+
+type StoredSandbox = {
+  version: number;
+  terms: { [term: string]: StoredTerm };
+};
+
+/**
+ * Order-independent identity of a term's sections. Two schedules with the same
+ * fingerprint hold the same sections, so the sandbox is unmodified.
+ */
+export const scheduleFingerprint = (
+  entries: readonly SandboxScheduleEntry[],
+): string =>
+  entries
+    .map((entry) => entry.section.id)
+    .sort((a, b) => a - b)
+    .join(',');
+
+/** Whether any term's sandbox differs from the user's real schedule. */
+export const isSandboxModified = (
+  sandboxByTerm: SandboxByTerm,
+  baseByTerm: SandboxByTerm,
+): boolean =>
+  Object.entries(sandboxByTerm).some(
+    ([term, sections]) =>
+      scheduleFingerprint(sections) !==
+      scheduleFingerprint(baseByTerm[term] ?? []),
+  );
+
+export const clearSwapSandbox = (userId: number): void => {
+  localStorage.removeItem(sandboxKey(userId));
+};
+
+export const saveSwapSandbox = (
+  userId: number,
+  sandboxByTerm: SandboxByTerm,
+  baseByTerm: SandboxByTerm,
+): void => {
+  const terms: StoredSandbox['terms'] = {};
+  Object.entries(sandboxByTerm).forEach(([term, sections]) => {
+    const base = scheduleFingerprint(baseByTerm[term] ?? []);
+    // A term swapped back to its original sections is not worth storing.
+    if (scheduleFingerprint(sections) === base) {
+      return;
+    }
+    terms[term] = { base, sections };
+  });
+
+  if (Object.keys(terms).length === 0) {
+    clearSwapSandbox(userId);
+    return;
+  }
+
+  const stored: StoredSandbox = { version: SANDBOX_VERSION, terms };
+  try {
+    localStorage.setItem(sandboxKey(userId), JSON.stringify(stored));
+  } catch {
+    // Storage full or unavailable (private mode): the sandbox stays in memory.
+  }
+};
+
+export const loadSwapSandbox = (
+  userId: number,
+  baseByTerm: SandboxByTerm,
+): SandboxByTerm => {
+  const raw = localStorage.getItem(sandboxKey(userId));
+  if (!raw) {
+    return {};
+  }
+
+  let stored: StoredSandbox | null = null;
+  try {
+    stored = JSON.parse(raw) as StoredSandbox;
+  } catch {
+    return {};
+  }
+  if (stored?.version !== SANDBOX_VERSION || !stored.terms) {
+    return {};
+  }
+
+  const restored: SandboxByTerm = {};
+  Object.entries(stored.terms).forEach(([term, entry]) => {
+    if (!entry?.sections?.length) {
+      return;
+    }
+    // Drop sandboxes branched off a schedule the user has since changed.
+    if (entry.base !== scheduleFingerprint(baseByTerm[term] ?? [])) {
+      return;
+    }
+    restored[term] = entry.sections;
+  });
+  return restored;
+};


### PR DESCRIPTION
## Persist the sandbox

Section swaps lived only in React state, so a refresh silently threw away a half-planned schedule and the "Reset" button was just a `window.location.reload()`.

New `src/pages/swapPage/sandboxStorage.ts`:

- Swaps are mirrored into `localStorage` per user (`swap_sandbox_<userId>`), keyed by term, and restored on mount.
- Each stored term records a fingerprint of the real schedule it was branched from. If the user re-imports a different schedule from Quest, that branch is discarded rather than replayed on a stale base.
- Never stored for the logged-out demo schedule.
- Writes are wrapped in `try`/`catch`, so private mode or a full quota leaves the sandbox working in memory.

Nothing is sent to the server, and real enrollment is still never touched.

## Reset button

Now shown only when the sandbox actually differs from the real schedule (an order-independent section-id comparison), so swapping a section and swapping it back hides it again. It clears the sandbox in memory and in storage — and drops the current selection, which a cross-course swap can leave pointing at a course the real schedule doesn't have.

## "Sandbox" wording

Page heading and `<title>`, meta description, logged-out login prompt, tour label and copy, panel empty state, section CTA (`Choose section` → `Try in sandbox`), reset button, announcement banner, and the profile dropdown entry (kept short as "Swap Sandbox" to fit the 150px menu).

## Testing

- `bun run lint-nofix` and `bunx tsc --noEmit` exit clean.
- New `src/pages/swapPage/__tests__/sandboxStorage.test.ts` — 8 tests covering round-trip, pruning a sandbox that matches the real schedule, stale-base rejection, per-user isolation, corrupt JSON, clear, and the modified check.

## Note

The banner's `BANNER_ID` is unchanged, so users who dismissed it won't see the reworded copy. Bump it if the new wording should resurface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)