### PR TITLE
fix(swap): surface Quest class numbers

### DIFF
--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -11826,6 +11826,7 @@ export type UserScheduleFragment = {
     user_id: number;
     section: {
       id: number;
+      class_number: number;
       section_name: string;
       exams: Array<{
         date: any;
@@ -12549,6 +12550,7 @@ export const UserScheduleFragmentDoc = gql`
       user_id
       section {
         id
+        class_number
         exams {
           date
           day

--- a/src/graphql/fragments/UserFragment.tsx
+++ b/src/graphql/fragments/UserFragment.tsx
@@ -32,6 +32,7 @@ const UserFragment = {
         user_id
         section {
           id
+          class_number
           exams {
             date
             day

--- a/src/pages/profilePage/ProfileCalendar.tsx
+++ b/src/pages/profilePage/ProfileCalendar.tsx
@@ -120,6 +120,11 @@ const getMomentsWithinRange = (
   return daysToReturn;
 };
 
+// e.g. "LEC 001 · Class #4021" — the class number is what students type into
+// Quest, so it rides along with the section label wherever we have it.
+const getMeetingSubtitle = ({ section, classNumber }: ScheduleInterval) =>
+  classNumber == null ? section : `${section} · Class #${classNumber}`;
+
 const getEventIntervals = (
   startDate: Moment,
   calendarDayRange: number,
@@ -162,6 +167,7 @@ const getEventIntervals = (
               courseCode: section.course.code,
               location: meeting.location,
               section: section.section_name,
+              classNumber: section.class_number,
             });
           }
         });
@@ -278,7 +284,8 @@ const buildWeekView = (
         endMinutes: event.end.hour() * 60 + event.end.minutes(),
         variant: getEventVariant(event.section),
         // Exams fold the section into the bold title; meetings show the code
-        // as the title with the section as the muted subtitle line.
+        // as the title with the section and its Quest class number as the
+        // muted subtitle line, matching the swap page.
         title: isExam ? (
           <>
             {courseLink}
@@ -288,7 +295,7 @@ const buildWeekView = (
         ) : (
           courseLink
         ),
-        subtitle: isExam ? undefined : event.section,
+        subtitle: isExam ? undefined : getMeetingSubtitle(event),
         // Compact 24-hour range to match the swap page, e.g. "08:30–09:20".
         timeLabel: `${event.start.format('HH:mm')}–${event.end.format(
           'HH:mm',

--- a/src/pages/swapPage/ScheduleSwapPanel.tsx
+++ b/src/pages/swapPage/ScheduleSwapPanel.tsx
@@ -97,23 +97,31 @@ const getMeetingTime = (meeting: SwapMeeting) => {
   )}`;
 };
 
-// Section names render as plain title text (no tag/badge); conflicting
-// sections dim with the rest of their row.
+// Show both UW's section label (e.g. "TUT 101") and the numeric class number
+// students need to enter in Quest. Conflicting sections dim with their row.
 const SectionName = ({
   sectionName,
+  classNumber,
   hasConflict,
 }: {
   sectionName: string;
+  classNumber: number;
   hasConflict: boolean;
 }) => (
-  <span
-    className={cn(
-      'text-sm font-semibold',
-      hasConflict ? 'text-dark3' : 'text-dark1',
-    )}
-  >
-    {sectionName}
-  </span>
+  <div className="flex flex-col gap-xs">
+    <span
+      className={cn(
+        'text-sm font-semibold',
+        hasConflict ? 'text-dark3' : 'text-dark1',
+      )}
+    >
+      {sectionName}
+    </span>
+    <span className={cn('text-xs', hasConflict ? 'text-dark3' : 'text-dark2')}>
+      Quest class number:{' '}
+      <strong className="font-semibold">{classNumber}</strong>
+    </span>
+  </div>
 );
 
 const MeetingInstructor = ({
@@ -267,8 +275,9 @@ const ScheduleSectionRow = ({
     >
       <div className="mb-2 flex items-start justify-between gap-2">
         <SectionName
-          sectionName={section.section_name}
+          classNumber={section.class_number}
           hasConflict={hasConflict}
+          sectionName={section.section_name}
         />
         {isEnrolled && (
           <span className="inline-flex items-center gap-1 text-xs font-semibold text-primary">

--- a/src/pages/swapPage/SwapCalendar.tsx
+++ b/src/pages/swapPage/SwapCalendar.tsx
@@ -205,7 +205,7 @@ const buildEnrolledEvents = (
           title: formatCourseCode(courseCode),
           timeLabel,
           location: m.location,
-          subtitle: section.section_name,
+          subtitle: `${section.section_name} · Class #${section.class_number}`,
           onClick: onToggleSection
             ? () => onToggleSection(courseCode, sectionType)
             : undefined,

--- a/src/pages/swapPage/demoSchedule.ts
+++ b/src/pages/swapPage/demoSchedule.ts
@@ -19,6 +19,7 @@ const demoSection = (
 ) => ({
   section: {
     id,
+    class_number: 10000 + Math.abs(id),
     exams: [],
     meetings: [
       {

--- a/src/types/Common.tsx
+++ b/src/types/Common.tsx
@@ -72,6 +72,9 @@ export type ScheduleInterval = {
   end: Moment;
   courseCode: string;
   section: string;
+  // Quest class number, for meeting intervals only (exams have no enrolment
+  // number to copy into Quest).
+  classNumber?: number;
   location?: string | null;
   truncate?: 'left' | 'right';
 };


### PR DESCRIPTION
## Summary

- show the Quest class number directly beneath each section label in the Swap Calendar panel
- include class numbers in the signed-in user schedule query and display them beside section labels on calendar blocks
- preserve conflict styling and give the logged-out demo stable sample class numbers

## Testing

- `bun run lint-nofix`
- `bun run build:vercel`