### PR TITLE
docs(skills): document the GraphQL codegen workflow

### DIFF
--- a/.agents/skills/fetch-backend-data/SKILL.md
+++ b/.agents/skills/fetch-backend-data/SKILL.md
@@ -12,17 +12,21 @@ This skill guides you through the full data-fetching stack: Postgres → Hasura 
 Credentials live in `uwflow/.env` (copy of `.env.sample`):
 
 ```
-POSTGRES_DB=flow
+POSTGRES_DB=flow_new
 POSTGRES_HOST=postgres   # or localhost if connecting outside Docker
 POSTGRES_PASSWORD=secretinprod
 POSTGRES_PORT=5432
 POSTGRES_USER=postgres
 ```
 
-Connect locally (backend must be running via `docker-compose`):
+Connect locally (backend must be running via `docker-compose`). Read the
+database name from `uwflow/.env` rather than assuming it — it is `flow_new`,
+not `flow`:
 
 ```bash
-psql -h localhost -p 5432 -U postgres -d flow
+psql -h localhost -p 5432 -U postgres -d flow_new
+# or, without a local psql client:
+docker exec -i postgres psql -U postgres -d flow_new
 ```
 
 Useful psql commands:
@@ -94,9 +98,48 @@ const MyComponent = ({ id }: { id: number }) => {
 };
 ```
 
-### Step 3 — Regenerate TypeScript types (if needed)
+### Step 3 — Regenerate TypeScript types
 
-Generated types live in `src/generated/graphql.tsx`. If the schema or queries changed, regenerate them per the project's codegen setup.
+`src/generated/graphql.tsx` is a **generated artifact. Never hand-edit it.**
+Adding a field to a fragment or writing a new query means regenerating:
+
+```bash
+bun run generate    # graphql-codegen --config codegen.js
+```
+
+Codegen introspects the **live local Hasura** (`codegen.js` points at
+`http://localhost:8080/v1/graphql` with `x-hasura-admin-secret: secretinprod`),
+so the backend must be running first. Postgres and Hasura are enough — the Go
+services are not needed:
+
+```bash
+cd uwflow && docker compose up -d postgres hasura
+```
+
+Codegen emits typed operations for every document under `src/**`. Use them
+instead of hand-writing operation types:
+
+```tsx
+import { GetMyDataQuery, GetMyDataQueryVariables } from 'generated/graphql';
+
+const { data } = useQuery<GetMyDataQuery, GetMyDataQueryVariables>(GET_MY_DATA);
+```
+
+A locally declared `type MyDataQuery = { ... }` sitting next to a `gql`
+document is a smell: it means codegen was never run for that query, and the
+hand-written type will silently drift from the schema.
+
+#### Check the diff before committing
+
+Codegen reads whatever schema your local Hasura currently has, so **any
+unmerged backend migration applied to your local database leaks into the
+output**. Regenerating while the backend repo sits on a feature branch adds
+types for tables that do not exist on `main`, inflating an unrelated frontend
+PR by hundreds of lines.
+
+Always `git diff src/generated/graphql.tsx` and confirm every hunk traces back
+to a change you actually made. If it does not, point codegen at a schema that
+matches what the PR targets before regenerating.
 
 ## 4. Authentication Context
 
@@ -114,4 +157,5 @@ Unauthenticated queries work as the `anonymous` role — only publicly visible d
 | GQL queries     | `uwflow_frontend/src/graphql/queries/`                |
 | Fragments       | `uwflow_frontend/src/graphql/fragments/`              |
 | Apollo init     | `uwflow_frontend/src/graphql/apollo.js`               |
-| Generated types | `uwflow_frontend/src/generated/graphql.tsx`           |
+| Generated types | `uwflow_frontend/src/generated/graphql.tsx` (never hand-edit) |
+| Codegen config  | `uwflow_frontend/codegen.js` (`bun run generate`)     |

--- a/.agents/skills/fetch-backend-data/SKILL.md
+++ b/.agents/skills/fetch-backend-data/SKILL.md
@@ -12,7 +12,7 @@ This skill guides you through the full data-fetching stack: Postgres → Hasura 
 Credentials live in `uwflow/.env` (copy of `.env.sample`):
 
 ```
-POSTGRES_DB=flow_new
+POSTGRES_DB=flow
 POSTGRES_HOST=postgres   # or localhost if connecting outside Docker
 POSTGRES_PASSWORD=secretinprod
 POSTGRES_PORT=5432


### PR DESCRIPTION
## Summary

`src/generated/graphql.tsx` is a generated artifact, but the `fetch-backend-data` skill only said to regenerate it "per the project's codegen setup." That is vague enough that hand-editing the file reads as acceptable — and it has been hand-edited in practice.

This fills in the real workflow:

- `bun run generate`, and the fact that it introspects the **live local Hasura**, so `docker compose up -d postgres hasura` must come first (the Go services are not needed)
- use the operation types codegen emits instead of hand-writing a `type FooQuery = { ... }` next to the `gql` document — a local declaration means codegen was never run for that query
- **check the diff before committing**: codegen reads whatever schema your local Hasura has, so an unmerged backend migration applied to your local database leaks unrelated types into the output

Also corrects the database name in the psql section — it is `flow_new`, not `flow` (verified against `uwflow/.env`), and adds a `docker exec` variant for machines without a local `psql` client.

## Context

Found while reviewing #286, which hand-edited `src/generated/graphql.tsx` to add a field. Regenerating properly showed two things the skill should have prevented:

1. the PR had never run codegen, so it hand-declared operation types that codegen already emits
2. regenerating against a local backend sitting on an unmerged feature branch pulled in ~460 lines of unrelated schema

## Verification

Docs only. No `src/` changes, so the eslint gate (which scans `src/`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)