### PR TITLE
fix(swap): link to the course's schedule-of-classes page

### DIFF
--- a/src/components/common/LastUpdatedSchedule.tsx
+++ b/src/components/common/LastUpdatedSchedule.tsx
@@ -5,7 +5,7 @@ import { splitCourseCode } from 'utils/Misc';
 
 import { LastUpdatedLink, LastUpdatedText } from './styles/LastUpdatedSchedule';
 
-const classesLink = 'http://classes.uwaterloo.ca/infocour/CIR/SA/index.html';
+const classesLink = 'https://classes.uwaterloo.ca/infocour/CIR/SA/index.html';
 
 type LastUpdatedScheduleProps = {
   margin?: string;
@@ -31,7 +31,7 @@ const LastUpdatedSchedule = ({
           courseNum.length < 3)
           ? 'under'
           : 'grad';
-      return `http://classes.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=${courseLevel}&sess=${term}&subject=${courseLetters}&cournum=${courseNum.toUpperCase()}`;
+      return `https://classes.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=${courseLevel}&sess=${term}&subject=${courseLetters}&cournum=${courseNum.toUpperCase()}`;
     }
     return classesLink;
   };

--- a/src/pages/swapPage/SwapCalendar.tsx
+++ b/src/pages/swapPage/SwapCalendar.tsx
@@ -655,8 +655,13 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
               )}
             </div>
             {updatedAt && (
+              // `updatedAt` comes from the sections of `displayCode` in
+              // `selectedTermCode`, so the link points at that exact course
+              // and term rather than the whole schedule-of-classes index.
               <LastUpdatedSchedule
                 updatedAt={updatedAt}
+                courseCode={displayCode ?? undefined}
+                term={selectedTermCode}
                 fontSize="80%"
                 margin="0"
               />


### PR DESCRIPTION
## Problem

On the swap page, the "Last updated N hours ago from classes.uwaterloo.ca" link pointed at the generic schedule-of-classes index:

```
https://classes.uwaterloo.ca/infocour/CIR/SA/index.html
```

instead of the page for the course actually being shown, e.g. for MATH 137 in 1269:

```
https://classes.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=under&sess=1269&subject=MATH&cournum=137
```

## Cause

`LastUpdatedSchedule` builds the deep link only when **both** `courseCode` and `term` are given, otherwise it falls back to the index page. `SwapCalendar` passed only `updatedAt`. The course page (`CourseSchedule.tsx`) already passes both — the swap page never did.

## Fix

- `SwapCalendar.tsx` passes `courseCode={displayCode}` and `term={selectedTermCode}`. These are the exact variables `GET_COURSE_FOR_SWAP` is queried with, and `updatedAt` is derived from that same result set (`moment.max` over those sections' `updated_at`), so the link and the timestamp always describe the same course and term.
- `LastUpdatedSchedule.tsx`: both `classes.uwaterloo.ca` URLs switched from `http://` to `https://`.

## Verification

- `tsc --noEmit` clean.
- ESLint clean.
- MATH 137 / 1269 now produces exactly the expected URL above.

## Note (not included)

This branch was developed in a git worktree under `.claude/worktrees/`, and `bun run lint-nofix` fails there with a `simple-import-sort` plugin-resolution error: the worktree sits inside the main checkout and `.eslintrc.js` has no `root: true`, so ESLint cascades into the parent config and loads the plugin twice. Pre-existing config quirk, unrelated to this change — adding `root: true` would fix it, but I left it out of this PR. Linted here with the equivalent `--no-eslintrc -c .eslintrc.js --resolve-plugins-relative-to .`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)