### PR TITLE
Prefer plain derivations over trivial useMemo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,23 @@ The following packages are intentionally pinned to their current major version a
 
 Before every commit, run `bun run lint-nofix` and confirm it exits clean. This is required by CI/CD — commits that fail it will not pass the pipeline.
 
+## React memoization
+
+Do **not** wrap cheap derived values in `useMemo` / `useCallback` by default.
+Plain assignments are preferred for small maps, filters, one-element arrays,
+and property reads.
+
+Only memoize when there is a concrete reason, for example:
+
+- the computation is measurably expensive, or
+- a stable identity is required to avoid a real over-render / effect loop
+  (document why in a short comment).
+
+A new `[]` / `{}` each render is fine unless a dependency array or
+`React.memo` child is clearly churning because of it — in that case prefer a
+module-level constant empty value over wrapping the whole derivation in
+`useMemo`.
+
 ## Design tokens (Tailwind)
 
 When writing Tailwind classes, use the named design tokens from

--- a/src/pages/swapPage/SwapCalendar.tsx
+++ b/src/pages/swapPage/SwapCalendar.tsx
@@ -315,13 +315,18 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
 
   const enrolledSectionIds = termSections.map((e) => e.section.id);
 
-  const conflictSectionIds = swapSections
-    .filter(
-      (section) =>
-        !enrolledSectionIds.includes(section.id) &&
-        sectionConflictsWithSchedule(section, termSections, selection),
-    )
-    .map((section) => section.id);
+  // Nested meeting-overlap checks across every candidate × enrolled section.
+  const conflictSectionIds = useMemo(
+    () =>
+      swapSections
+        .filter(
+          (section) =>
+            !enrolledSectionIds.includes(section.id) &&
+            sectionConflictsWithSchedule(section, termSections, selection),
+        )
+        .map((section) => section.id),
+    [swapSections, enrolledSectionIds, termSections, selection],
+  );
 
   // Sections of the selected type shown in the panel (mirrors the panel's term
   // + type filter). Used to detect a section code that has nothing to swap into.

--- a/src/pages/swapPage/SwapCalendar.tsx
+++ b/src/pages/swapPage/SwapCalendar.tsx
@@ -298,44 +298,30 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
     skip: !displayCode,
   });
 
-  const swapSections = useMemo(
-    () => (displayCode ? sectionsData?.course_section ?? [] : []),
-    [displayCode, sectionsData],
-  );
+  const swapSections = displayCode ? sectionsData?.course_section ?? [] : [];
   const displayedCourse = swapSections[0]?.course;
 
   // Bridge the panel's id-based API with this page's course-code state.
-  const candidateCourses = useMemo<SwapCandidateCourse[]>(
-    () =>
-      displayedCourse
-        ? [
-            {
-              id: displayedCourse.id,
-              code: displayedCourse.code,
-              name: displayedCourse.name,
-              sections: swapSections,
-            },
-          ]
-        : [],
-    [displayedCourse, swapSections],
-  );
+  const candidateCourses: SwapCandidateCourse[] = displayedCourse
+    ? [
+        {
+          id: displayedCourse.id,
+          code: displayedCourse.code,
+          name: displayedCourse.name,
+          sections: swapSections,
+        },
+      ]
+    : [];
 
-  const enrolledSectionIds = useMemo(
-    () => termSections.map((e) => e.section.id),
-    [termSections],
-  );
+  const enrolledSectionIds = termSections.map((e) => e.section.id);
 
-  const conflictSectionIds = useMemo(
-    () =>
-      swapSections
-        .filter(
-          (section) =>
-            !enrolledSectionIds.includes(section.id) &&
-            sectionConflictsWithSchedule(section, termSections, selection),
-        )
-        .map((section) => section.id),
-    [swapSections, enrolledSectionIds, termSections, selection],
-  );
+  const conflictSectionIds = swapSections
+    .filter(
+      (section) =>
+        !enrolledSectionIds.includes(section.id) &&
+        sectionConflictsWithSchedule(section, termSections, selection),
+    )
+    .map((section) => section.id);
 
   // Sections of the selected type shown in the panel (mirrors the panel's term
   // + type filter). Used to detect a section code that has nothing to swap into.


### PR DESCRIPTION
## Summary
- Add React memoization guidance to `AGENTS.md`: do not wrap cheap derived values in `useMemo` / `useCallback` by default.
- Remove trivial `useMemo` wrappers around `swapSections`, `candidateCourses`, `enrolledSectionIds`, and `conflictSectionIds` in `SwapCalendar`.

## Test plan
- [ ] `bun run lint-nofix` passes
- [ ] Swap page still shows enrolled/conflict sections correctly when selecting a course
- [ ] Panel candidate list still populates for the selected swap target


Made with [Cursor](https://cursor.com)