### PR TITLE
Let swap course dropdowns own their open state

### DIFF
--- a/src/pages/swapPage/CourseSearchDropdown.tsx
+++ b/src/pages/swapPage/CourseSearchDropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { ChevronDown } from 'react-feather';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import { useQuery } from '@apollo/client';
 import fuzzysort from 'fuzzysort';
@@ -6,6 +7,7 @@ import {
   CourseDropdownByTermQuery,
   CourseDropdownByTermQueryVariables,
 } from 'generated/graphql';
+import useOnClickOutside from 'use-onclickoutside';
 
 import { COURSE_DROPDOWN_TERM_QUERY } from 'graphql/queries/course/SwapCourse';
 import { cn } from 'lib/utils';
@@ -17,9 +19,11 @@ const dropdownEmptyStateClasses =
 type CourseItem = CourseDropdownByTermQuery['course'][number];
 
 type CourseSearchDropdownProps = {
+  /** Code shown on the trigger (swap target, or enrolled course as fallback). */
+  displayCode: string;
+  /** Highlighted row in the list; null when still targeting the enrolled course. */
   selectedCode: string | null;
   onSelect: (code: string) => void;
-  onClose: () => void;
   termId: number;
 };
 
@@ -60,40 +64,40 @@ const CourseRow = ({
   );
 };
 
+// Owns its own open state — same pattern as SearchBar / DropdownList.
 const CourseSearchDropdown = ({
+  displayCode,
   selectedCode,
   onSelect,
-  onClose,
   termId,
 }: CourseSearchDropdownProps) => {
-  const [searchQuery, setSearchQuery] = useState('');
+  const ref = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  useOnClickOutside(ref, () => setOpen(false));
 
   useEffect(() => {
+    if (!open) {
+      setSearchQuery('');
+      return;
+    }
     inputRef.current?.focus();
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') setOpen(false);
     };
-
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
-
-  // Let keyboard users dismiss the dropdown with Escape, matching the
-  // pointer-only backdrop click.
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
+  }, [open]);
 
   const { data, loading } = useQuery<
     CourseDropdownByTermQuery,
     CourseDropdownByTermQueryVariables
-  >(COURSE_DROPDOWN_TERM_QUERY, { variables: { termId } });
+  >(COURSE_DROPDOWN_TERM_QUERY, {
+    variables: { termId },
+    skip: !open,
+  });
 
   const allCourses: CourseItem[] = data?.course ?? [];
 
@@ -130,10 +134,15 @@ const CourseSearchDropdown = ({
       .map((entry) => entry.course);
   }
 
+  const handleSelect = (code: string) => {
+    onSelect(code);
+    setOpen(false);
+  };
+
   const itemData: RowData = {
     courses: filteredCourses,
     selectedCode,
-    onSelect,
+    onSelect: handleSelect,
   };
   const listHeight = Math.min(
     filteredCourses.length * ITEM_HEIGHT,
@@ -165,19 +174,33 @@ const CourseSearchDropdown = ({
   };
 
   return (
-    <>
-      <div className="fixed inset-0 z-[199]" onClick={onClose} />
-      <div className="absolute right-0 top-[calc(100%+8px)] z-[200] flex max-h-[360px] min-w-[300px] flex-col overflow-hidden rounded border border-solid border-light3 bg-white shadow-[0_4px_20px_rgba(0,0,0,0.12)]">
-        <input
-          ref={inputRef}
-          className="box-border w-full shrink-0 border-0 border-b border-solid border-light2 bg-transparent px-3.5 py-2.5 font-inter text-sm font-normal outline-none placeholder:text-dark3"
-          placeholder="Search courses…"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
+    <div className="relative min-w-0" ref={ref}>
+      <button
+        aria-expanded={open}
+        className="flex h-8 min-w-0 max-w-full cursor-pointer items-center gap-1 border-none bg-transparent p-0 font-inter text-sm font-semibold text-courses outline-none hover:underline"
+        onClick={() => setOpen((prev) => !prev)}
+        type="button"
+      >
+        <span className="truncate">{formatCourseCode(displayCode)}</span>
+        <ChevronDown
+          aria-hidden="true"
+          className="shrink-0 text-courses"
+          size={14}
         />
-        <div className="flex-1 overflow-y-auto">{renderBody()}</div>
-      </div>
-    </>
+      </button>
+      {open && (
+        <div className="absolute right-0 top-[calc(100%+8px)] z-[200] flex max-h-[360px] min-w-[300px] flex-col overflow-hidden rounded border border-solid border-light3 bg-white shadow-[0_4px_20px_rgba(0,0,0,0.12)]">
+          <input
+            ref={inputRef}
+            className="box-border w-full shrink-0 border-0 border-b border-solid border-light2 bg-transparent px-3.5 py-2.5 font-inter text-sm font-normal outline-none placeholder:text-dark3"
+            placeholder="Search courses…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+          <div className="flex-1 overflow-y-auto">{renderBody()}</div>
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/pages/swapPage/EnrolledCourseDropdown.tsx
+++ b/src/pages/swapPage/EnrolledCourseDropdown.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
+import { ChevronDown } from 'react-feather';
+import useOnClickOutside from 'use-onclickoutside';
 
 import { cn } from 'lib/utils';
 import { formatCourseCode } from 'utils/Misc';
@@ -10,46 +12,70 @@ export type EnrolledCourse = {
 
 type EnrolledCourseDropdownProps = {
   courses: EnrolledCourse[];
-  selectedCode: string | null;
+  selectedCode: string;
   onSelect: (code: string) => void;
-  onClose: () => void;
 };
 
 // Lightweight dropdown over the courses already in the user's schedule. Unlike
 // CourseSearchDropdown (which searches every course in the term via GraphQL),
 // this list is small and comes straight from the loaded schedule, so there's
-// no search box, query, or virtualization.
+// no search box, query, or virtualization. Owns its own open state — same
+// pattern as SearchBar / DropdownList.
 const EnrolledCourseDropdown = ({
   courses,
   selectedCode,
   onSelect,
-  onClose,
-}: EnrolledCourseDropdownProps) => (
-  <>
-    <div className="fixed inset-0 z-[199]" onClick={onClose} />
-    <div className="absolute left-0 top-[calc(100%+8px)] z-[200] flex max-h-[360px] min-w-[240px] flex-col overflow-hidden rounded border border-solid border-light3 bg-white shadow-[0_4px_20px_rgba(0,0,0,0.12)]">
-      <div className="overflow-y-auto">
-        {courses.map((course) => (
-          <button
-            key={course.code}
-            type="button"
-            className={cn(
-              'flex w-full cursor-pointer items-center border-0 border-b border-solid border-light2 px-3.5 py-2.5 text-left font-inter last:border-b-0 hover:bg-light1',
-              course.code === selectedCode ? 'bg-[#eef4ff]' : 'bg-transparent',
-            )}
-            onClick={() => onSelect(course.code)}
-          >
-            <span className="shrink-0 text-[13px] font-bold text-courses">
-              {formatCourseCode(course.code)}
-            </span>
-            <span className="ml-2 min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-xs text-dark3">
-              {course.name}
-            </span>
-          </button>
-        ))}
-      </div>
+}: EnrolledCourseDropdownProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  useOnClickOutside(ref, () => setOpen(false));
+
+  return (
+    <div className="relative min-w-0" ref={ref}>
+      <button
+        aria-expanded={open}
+        className="flex h-8 min-w-0 max-w-full cursor-pointer items-center gap-1 border-none bg-transparent p-0 font-inter text-sm font-semibold text-courses outline-none hover:underline"
+        onClick={() => setOpen((prev) => !prev)}
+        type="button"
+      >
+        <span className="truncate">{formatCourseCode(selectedCode)}</span>
+        <ChevronDown
+          aria-hidden="true"
+          className="shrink-0 text-courses"
+          size={14}
+        />
+      </button>
+      {open && (
+        <div className="absolute left-0 top-[calc(100%+8px)] z-[200] flex max-h-[360px] min-w-[240px] flex-col overflow-hidden rounded border border-solid border-light3 bg-white shadow-[0_4px_20px_rgba(0,0,0,0.12)]">
+          <div className="overflow-y-auto">
+            {courses.map((course) => (
+              <button
+                key={course.code}
+                type="button"
+                className={cn(
+                  'flex w-full cursor-pointer items-center border-0 border-b border-solid border-light2 px-3.5 py-2.5 text-left font-inter last:border-b-0 hover:bg-light1',
+                  course.code === selectedCode
+                    ? 'bg-[#eef4ff]'
+                    : 'bg-transparent',
+                )}
+                onClick={() => {
+                  onSelect(course.code);
+                  setOpen(false);
+                }}
+              >
+                <span className="shrink-0 text-[13px] font-bold text-courses">
+                  {formatCourseCode(course.code)}
+                </span>
+                <span className="ml-2 min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-xs text-dark3">
+                  {course.name}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
-  </>
-);
+  );
+};
 
 export default EnrolledCourseDropdown;

--- a/src/pages/swapPage/SwapCalendar.tsx
+++ b/src/pages/swapPage/SwapCalendar.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { ChevronDown, RotateCcw } from 'react-feather';
+import { RotateCcw } from 'react-feather';
 import { useQuery } from '@apollo/client';
 import * as Sentry from '@sentry/react';
 import {
@@ -243,9 +243,6 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
   const [selectedSwapCourseCode, setSelectedSwapCourseCode] = useState<
     string | null
   >(null);
-  const [isSwapDropdownOpen, setIsSwapDropdownOpen] = useState(false);
-  // The left selector lists courses the user is already enrolled in.
-  const [isCourseDropdownOpen, setIsCourseDropdownOpen] = useState(false);
   // Temporary client-side section swaps, keyed by term label. A swap replaces
   // the matching schedule entry in React state only — refreshing the page
   // restores the original schedule (no persistence, no mutations).
@@ -256,8 +253,6 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
   useEffect(() => {
     setSelectedSwapCourseCode(null);
     setHoveredSection(null);
-    setIsSwapDropdownOpen(false);
-    setIsCourseDropdownOpen(false);
   }, [selectedCourseCode, selectedSectionType]);
 
   const selectedTermCode =
@@ -432,8 +427,6 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
     setSelection(null);
     setSelectedSwapCourseCode(null);
     setHoveredSection(null);
-    setIsSwapDropdownOpen(false);
-    setIsCourseDropdownOpen(false);
   }, []);
 
   const handleCourseChange = useCallback((courseCode: string | null) => {
@@ -450,7 +443,6 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
         .map((e) => getSectionType(e.section.section_name));
       const sectionType = types.includes('LEC') ? 'LEC' : types[0];
       if (sectionType) setSelection({ courseCode, sectionType });
-      setIsCourseDropdownOpen(false);
     },
     [termSections],
   );
@@ -572,58 +564,20 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
               {selectedCourseCode ? (
                 <>
                   <span className="text-sm font-semibold text-dark1">Swap</span>
-                  <div className="relative min-w-0">
-                    <button
-                      className="flex h-8 min-w-0 max-w-full cursor-pointer items-center gap-1 border-none bg-transparent p-0 font-inter text-sm font-semibold text-courses outline-none hover:underline"
-                      onClick={() => setIsCourseDropdownOpen((open) => !open)}
-                      type="button"
-                    >
-                      <span className="truncate">
-                        {formatCourseCode(selectedCourseCode)}
-                      </span>
-                      <ChevronDown
-                        aria-hidden="true"
-                        className="shrink-0 text-courses"
-                        size={14}
-                      />
-                    </button>
-                    {isCourseDropdownOpen && (
-                      <EnrolledCourseDropdown
-                        courses={enrolledCourses}
-                        selectedCode={selectedCourseCode}
-                        onSelect={handleSelectEnrolledCourse}
-                        onClose={() => setIsCourseDropdownOpen(false)}
-                      />
-                    )}
-                  </div>
+                  <EnrolledCourseDropdown
+                    key={`${selectedCourseCode}|${selectedSectionType}`}
+                    courses={enrolledCourses}
+                    selectedCode={selectedCourseCode}
+                    onSelect={handleSelectEnrolledCourse}
+                  />
                   <span className="text-sm font-semibold text-dark1">with</span>
-                  <div className="relative min-w-0">
-                    <button
-                      className="flex h-8 min-w-0 max-w-full cursor-pointer items-center gap-1 border-none bg-transparent p-0 font-inter text-sm font-semibold text-courses outline-none hover:underline"
-                      onClick={() => setIsSwapDropdownOpen((open) => !open)}
-                      type="button"
-                    >
-                      <span className="truncate">
-                        {formatCourseCode(swapTargetCode ?? selectedCourseCode)}
-                      </span>
-                      <ChevronDown
-                        aria-hidden="true"
-                        className="shrink-0 text-courses"
-                        size={14}
-                      />
-                    </button>
-                    {isSwapDropdownOpen && (
-                      <CourseSearchDropdown
-                        selectedCode={swapTargetCode}
-                        onSelect={(code) => {
-                          setIsSwapDropdownOpen(false);
-                          handleCourseChange(code);
-                        }}
-                        onClose={() => setIsSwapDropdownOpen(false)}
-                        termId={selectedTermCode}
-                      />
-                    )}
-                  </div>
+                  <CourseSearchDropdown
+                    key={`${selectedCourseCode}|${selectedSectionType}|${selectedTermCode}`}
+                    displayCode={swapTargetCode ?? selectedCourseCode}
+                    selectedCode={swapTargetCode}
+                    onSelect={handleCourseChange}
+                    termId={selectedTermCode}
+                  />
                 </>
               ) : (
                 <span className="text-sm text-dark3">


### PR DESCRIPTION
## Summary
- Move open-state, trigger button, and click-outside dismiss into `EnrolledCourseDropdown` and `CourseSearchDropdown` (same pattern as SearchBar / DropdownList).
- Slim `SwapCalendar` so it no longer owns `isCourseDropdownOpen` / `isSwapDropdownOpen`; remount via `key` when selection/term changes so menus reset.

## Test plan
- [ ] Open enrolled-course dropdown, click outside → closes
- [ ] Open swap-target search dropdown, Escape / click outside → closes
- [ ] Selecting a course from either dropdown updates the toolbar and closes the menu
- [ ] Changing calendar selection or term remounts dropdowns closed
- [ ] `bun run lint-nofix` passes


Made with [Cursor](https://cursor.com)