### PR TITLE
Persist Swap page plans in the backend

### DIFF
--- a/src/constants/Messages.tsx
+++ b/src/constants/Messages.tsx
@@ -66,6 +66,9 @@ export const SCHEDULE_CLASSES_SKIPPED = (classes: number[]) =>
     classes.length === 1 ? 'class number' : 'class numbers'
   } ${joinClassNumbers(classes)}, which we couldn’t find.`;
 
+export const SCHEDULE_SWAP_ERROR =
+  'Sorry, we couldn’t save your swapped sections – try again in a few minutes.';
+
 export const SUBSCRIPTION_ERROR =
   'Sorry, we couldn’t sign you up for notifications – try again in a few minutes.';
 

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -4578,6 +4578,10 @@ export type Mutation_Root = {
   delete_user_course_taken?: Maybe<User_Course_Taken_Mutation_Response>;
   /** delete data from the table: "user_schedule" */
   delete_user_schedule?: Maybe<User_Schedule_Mutation_Response>;
+  /** delete data from the table: "user_schedule_swap" */
+  delete_user_schedule_swap?: Maybe<User_Schedule_Swap_Mutation_Response>;
+  /** delete single row from the table: "user_schedule_swap" */
+  delete_user_schedule_swap_by_pk?: Maybe<User_Schedule_Swap>;
   /** delete data from the table: "user_shortlist" */
   delete_user_shortlist?: Maybe<User_Shortlist_Mutation_Response>;
   /** insert data into the table: "course" */
@@ -4644,6 +4648,10 @@ export type Mutation_Root = {
   insert_user_schedule?: Maybe<User_Schedule_Mutation_Response>;
   /** insert a single row into the table: "user_schedule" */
   insert_user_schedule_one?: Maybe<User_Schedule>;
+  /** insert data into the table: "user_schedule_swap" */
+  insert_user_schedule_swap?: Maybe<User_Schedule_Swap_Mutation_Response>;
+  /** insert a single row into the table: "user_schedule_swap" */
+  insert_user_schedule_swap_one?: Maybe<User_Schedule_Swap>;
   /** insert data into the table: "user_shortlist" */
   insert_user_shortlist?: Maybe<User_Shortlist_Mutation_Response>;
   /** insert a single row into the table: "user_shortlist" */
@@ -4747,6 +4755,14 @@ export type Mutation_Root = {
   /** update multiples rows of table: "user_schedule" */
   update_user_schedule_many?: Maybe<
     Array<Maybe<User_Schedule_Mutation_Response>>
+  >;
+  /** update data of the table: "user_schedule_swap" */
+  update_user_schedule_swap?: Maybe<User_Schedule_Swap_Mutation_Response>;
+  /** update single row of the table: "user_schedule_swap" */
+  update_user_schedule_swap_by_pk?: Maybe<User_Schedule_Swap>;
+  /** update multiples rows of table: "user_schedule_swap" */
+  update_user_schedule_swap_many?: Maybe<
+    Array<Maybe<User_Schedule_Swap_Mutation_Response>>
   >;
   /** update data of the table: "user_shortlist" */
   update_user_shortlist?: Maybe<User_Shortlist_Mutation_Response>;
@@ -4864,6 +4880,17 @@ export type Mutation_RootDelete_User_Course_TakenArgs = {
 /** mutation root */
 export type Mutation_RootDelete_User_ScheduleArgs = {
   where: User_Schedule_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootDelete_User_Schedule_SwapArgs = {
+  where: User_Schedule_Swap_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootDelete_User_Schedule_Swap_By_PkArgs = {
+  source_section_id: Scalars['Int']['input'];
+  user_id: Scalars['Int']['input'];
 };
 
 /** mutation root */
@@ -5055,6 +5082,18 @@ export type Mutation_RootInsert_User_ScheduleArgs = {
 export type Mutation_RootInsert_User_Schedule_OneArgs = {
   object: User_Schedule_Insert_Input;
   on_conflict?: InputMaybe<User_Schedule_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_User_Schedule_SwapArgs = {
+  objects: Array<User_Schedule_Swap_Insert_Input>;
+  on_conflict?: InputMaybe<User_Schedule_Swap_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_User_Schedule_Swap_OneArgs = {
+  object: User_Schedule_Swap_Insert_Input;
+  on_conflict?: InputMaybe<User_Schedule_Swap_On_Conflict>;
 };
 
 /** mutation root */
@@ -5301,6 +5340,25 @@ export type Mutation_RootUpdate_User_ScheduleArgs = {
 /** mutation root */
 export type Mutation_RootUpdate_User_Schedule_ManyArgs = {
   updates: Array<User_Schedule_Updates>;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_User_Schedule_SwapArgs = {
+  _inc?: InputMaybe<User_Schedule_Swap_Inc_Input>;
+  _set?: InputMaybe<User_Schedule_Swap_Set_Input>;
+  where: User_Schedule_Swap_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_User_Schedule_Swap_By_PkArgs = {
+  _inc?: InputMaybe<User_Schedule_Swap_Inc_Input>;
+  _set?: InputMaybe<User_Schedule_Swap_Set_Input>;
+  pk_columns: User_Schedule_Swap_Pk_Columns_Input;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_User_Schedule_Swap_ManyArgs = {
+  updates: Array<User_Schedule_Swap_Updates>;
 };
 
 /** mutation root */
@@ -6588,6 +6646,12 @@ export type Query_Root = {
   user_schedule: Array<User_Schedule>;
   /** fetch aggregated fields from the table: "user_schedule" */
   user_schedule_aggregate: User_Schedule_Aggregate;
+  /** fetch data from the table: "user_schedule_swap" */
+  user_schedule_swap: Array<User_Schedule_Swap>;
+  /** fetch aggregated fields from the table: "user_schedule_swap" */
+  user_schedule_swap_aggregate: User_Schedule_Swap_Aggregate;
+  /** fetch data from the table: "user_schedule_swap" using primary key columns */
+  user_schedule_swap_by_pk?: Maybe<User_Schedule_Swap>;
   /** fetch data from the table: "user_shortlist" */
   user_shortlist: Array<User_Shortlist>;
   /** fetch aggregated fields from the table: "user_shortlist" */
@@ -7108,6 +7172,27 @@ export type Query_RootUser_Schedule_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<User_Schedule_Order_By>>;
   where?: InputMaybe<User_Schedule_Bool_Exp>;
+};
+
+export type Query_RootUser_Schedule_SwapArgs = {
+  distinct_on?: InputMaybe<Array<User_Schedule_Swap_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<User_Schedule_Swap_Order_By>>;
+  where?: InputMaybe<User_Schedule_Swap_Bool_Exp>;
+};
+
+export type Query_RootUser_Schedule_Swap_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<User_Schedule_Swap_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<User_Schedule_Swap_Order_By>>;
+  where?: InputMaybe<User_Schedule_Swap_Bool_Exp>;
+};
+
+export type Query_RootUser_Schedule_Swap_By_PkArgs = {
+  source_section_id: Scalars['Int']['input'];
+  user_id: Scalars['Int']['input'];
 };
 
 export type Query_RootUser_ShortlistArgs = {
@@ -9495,6 +9580,14 @@ export type Subscription_Root = {
   user_schedule_aggregate: User_Schedule_Aggregate;
   /** fetch data from the table in a streaming manner: "user_schedule" */
   user_schedule_stream: Array<User_Schedule>;
+  /** fetch data from the table: "user_schedule_swap" */
+  user_schedule_swap: Array<User_Schedule_Swap>;
+  /** fetch aggregated fields from the table: "user_schedule_swap" */
+  user_schedule_swap_aggregate: User_Schedule_Swap_Aggregate;
+  /** fetch data from the table: "user_schedule_swap" using primary key columns */
+  user_schedule_swap_by_pk?: Maybe<User_Schedule_Swap>;
+  /** fetch data from the table in a streaming manner: "user_schedule_swap" */
+  user_schedule_swap_stream: Array<User_Schedule_Swap>;
   /** fetch data from the table: "user_shortlist" */
   user_shortlist: Array<User_Shortlist>;
   /** fetch aggregated fields from the table: "user_shortlist" */
@@ -10185,6 +10278,33 @@ export type Subscription_RootUser_Schedule_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<User_Schedule_Stream_Cursor_Input>>;
   where?: InputMaybe<User_Schedule_Bool_Exp>;
+};
+
+export type Subscription_RootUser_Schedule_SwapArgs = {
+  distinct_on?: InputMaybe<Array<User_Schedule_Swap_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<User_Schedule_Swap_Order_By>>;
+  where?: InputMaybe<User_Schedule_Swap_Bool_Exp>;
+};
+
+export type Subscription_RootUser_Schedule_Swap_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<User_Schedule_Swap_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<User_Schedule_Swap_Order_By>>;
+  where?: InputMaybe<User_Schedule_Swap_Bool_Exp>;
+};
+
+export type Subscription_RootUser_Schedule_Swap_By_PkArgs = {
+  source_section_id: Scalars['Int']['input'];
+  user_id: Scalars['Int']['input'];
+};
+
+export type Subscription_RootUser_Schedule_Swap_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<User_Schedule_Swap_Stream_Cursor_Input>>;
+  where?: InputMaybe<User_Schedule_Swap_Bool_Exp>;
 };
 
 export type Subscription_RootUser_ShortlistArgs = {
@@ -11012,6 +11132,13 @@ export type User_Schedule_Mutation_Response = {
   returning: Array<User_Schedule>;
 };
 
+/** input type for inserting object relation for remote table "user_schedule" */
+export type User_Schedule_Obj_Rel_Insert_Input = {
+  data: User_Schedule_Insert_Input;
+  /** upsert condition */
+  on_conflict?: InputMaybe<User_Schedule_On_Conflict>;
+};
+
 /** on_conflict condition type for table "user_schedule" */
 export type User_Schedule_On_Conflict = {
   constraint: User_Schedule_Constraint;
@@ -11110,6 +11237,243 @@ export type User_Schedule_Sum_Fields = {
 export type User_Schedule_Sum_Order_By = {
   section_id?: InputMaybe<Order_By>;
   user_id?: InputMaybe<Order_By>;
+};
+
+/** columns and relationships of "user_schedule_swap" */
+export type User_Schedule_Swap = {
+  __typename?: 'user_schedule_swap';
+  /** An object relationship */
+  replacement_section: Course_Section;
+  replacement_section_id: Scalars['Int']['output'];
+  /** An object relationship */
+  source_schedule: User_Schedule;
+  source_section_id: Scalars['Int']['output'];
+  user_id: Scalars['Int']['output'];
+};
+
+/** aggregated selection of "user_schedule_swap" */
+export type User_Schedule_Swap_Aggregate = {
+  __typename?: 'user_schedule_swap_aggregate';
+  aggregate?: Maybe<User_Schedule_Swap_Aggregate_Fields>;
+  nodes: Array<User_Schedule_Swap>;
+};
+
+/** aggregate fields of "user_schedule_swap" */
+export type User_Schedule_Swap_Aggregate_Fields = {
+  __typename?: 'user_schedule_swap_aggregate_fields';
+  avg?: Maybe<User_Schedule_Swap_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<User_Schedule_Swap_Max_Fields>;
+  min?: Maybe<User_Schedule_Swap_Min_Fields>;
+  stddev?: Maybe<User_Schedule_Swap_Stddev_Fields>;
+  stddev_pop?: Maybe<User_Schedule_Swap_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<User_Schedule_Swap_Stddev_Samp_Fields>;
+  sum?: Maybe<User_Schedule_Swap_Sum_Fields>;
+  var_pop?: Maybe<User_Schedule_Swap_Var_Pop_Fields>;
+  var_samp?: Maybe<User_Schedule_Swap_Var_Samp_Fields>;
+  variance?: Maybe<User_Schedule_Swap_Variance_Fields>;
+};
+
+/** aggregate fields of "user_schedule_swap" */
+export type User_Schedule_Swap_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<User_Schedule_Swap_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type User_Schedule_Swap_Avg_Fields = {
+  __typename?: 'user_schedule_swap_avg_fields';
+  replacement_section_id?: Maybe<Scalars['Float']['output']>;
+  source_section_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "user_schedule_swap". All fields are combined with a logical 'AND'. */
+export type User_Schedule_Swap_Bool_Exp = {
+  _and?: InputMaybe<Array<User_Schedule_Swap_Bool_Exp>>;
+  _not?: InputMaybe<User_Schedule_Swap_Bool_Exp>;
+  _or?: InputMaybe<Array<User_Schedule_Swap_Bool_Exp>>;
+  replacement_section?: InputMaybe<Course_Section_Bool_Exp>;
+  replacement_section_id?: InputMaybe<Int_Comparison_Exp>;
+  source_schedule?: InputMaybe<User_Schedule_Bool_Exp>;
+  source_section_id?: InputMaybe<Int_Comparison_Exp>;
+  user_id?: InputMaybe<Int_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "user_schedule_swap" */
+export enum User_Schedule_Swap_Constraint {
+  /** unique or primary key constraint on columns "user_id", "source_section_id" */
+  UserScheduleSwapPkey = 'user_schedule_swap_pkey',
+}
+
+/** input type for incrementing numeric columns in table "user_schedule_swap" */
+export type User_Schedule_Swap_Inc_Input = {
+  replacement_section_id?: InputMaybe<Scalars['Int']['input']>;
+  source_section_id?: InputMaybe<Scalars['Int']['input']>;
+  user_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** input type for inserting data into table "user_schedule_swap" */
+export type User_Schedule_Swap_Insert_Input = {
+  replacement_section?: InputMaybe<Course_Section_Obj_Rel_Insert_Input>;
+  replacement_section_id?: InputMaybe<Scalars['Int']['input']>;
+  source_schedule?: InputMaybe<User_Schedule_Obj_Rel_Insert_Input>;
+  source_section_id?: InputMaybe<Scalars['Int']['input']>;
+  user_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate max on columns */
+export type User_Schedule_Swap_Max_Fields = {
+  __typename?: 'user_schedule_swap_max_fields';
+  replacement_section_id?: Maybe<Scalars['Int']['output']>;
+  source_section_id?: Maybe<Scalars['Int']['output']>;
+  user_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate min on columns */
+export type User_Schedule_Swap_Min_Fields = {
+  __typename?: 'user_schedule_swap_min_fields';
+  replacement_section_id?: Maybe<Scalars['Int']['output']>;
+  source_section_id?: Maybe<Scalars['Int']['output']>;
+  user_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** response of any mutation on the table "user_schedule_swap" */
+export type User_Schedule_Swap_Mutation_Response = {
+  __typename?: 'user_schedule_swap_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int']['output'];
+  /** data from the rows affected by the mutation */
+  returning: Array<User_Schedule_Swap>;
+};
+
+/** on_conflict condition type for table "user_schedule_swap" */
+export type User_Schedule_Swap_On_Conflict = {
+  constraint: User_Schedule_Swap_Constraint;
+  update_columns?: Array<User_Schedule_Swap_Update_Column>;
+  where?: InputMaybe<User_Schedule_Swap_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "user_schedule_swap". */
+export type User_Schedule_Swap_Order_By = {
+  replacement_section?: InputMaybe<Course_Section_Order_By>;
+  replacement_section_id?: InputMaybe<Order_By>;
+  source_schedule?: InputMaybe<User_Schedule_Order_By>;
+  source_section_id?: InputMaybe<Order_By>;
+  user_id?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: user_schedule_swap */
+export type User_Schedule_Swap_Pk_Columns_Input = {
+  source_section_id: Scalars['Int']['input'];
+  user_id: Scalars['Int']['input'];
+};
+
+/** select columns of table "user_schedule_swap" */
+export enum User_Schedule_Swap_Select_Column {
+  /** column name */
+  ReplacementSectionId = 'replacement_section_id',
+  /** column name */
+  SourceSectionId = 'source_section_id',
+  /** column name */
+  UserId = 'user_id',
+}
+
+/** input type for updating data in table "user_schedule_swap" */
+export type User_Schedule_Swap_Set_Input = {
+  replacement_section_id?: InputMaybe<Scalars['Int']['input']>;
+  source_section_id?: InputMaybe<Scalars['Int']['input']>;
+  user_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate stddev on columns */
+export type User_Schedule_Swap_Stddev_Fields = {
+  __typename?: 'user_schedule_swap_stddev_fields';
+  replacement_section_id?: Maybe<Scalars['Float']['output']>;
+  source_section_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type User_Schedule_Swap_Stddev_Pop_Fields = {
+  __typename?: 'user_schedule_swap_stddev_pop_fields';
+  replacement_section_id?: Maybe<Scalars['Float']['output']>;
+  source_section_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type User_Schedule_Swap_Stddev_Samp_Fields = {
+  __typename?: 'user_schedule_swap_stddev_samp_fields';
+  replacement_section_id?: Maybe<Scalars['Float']['output']>;
+  source_section_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "user_schedule_swap" */
+export type User_Schedule_Swap_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: User_Schedule_Swap_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type User_Schedule_Swap_Stream_Cursor_Value_Input = {
+  replacement_section_id?: InputMaybe<Scalars['Int']['input']>;
+  source_section_id?: InputMaybe<Scalars['Int']['input']>;
+  user_id?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate sum on columns */
+export type User_Schedule_Swap_Sum_Fields = {
+  __typename?: 'user_schedule_swap_sum_fields';
+  replacement_section_id?: Maybe<Scalars['Int']['output']>;
+  source_section_id?: Maybe<Scalars['Int']['output']>;
+  user_id?: Maybe<Scalars['Int']['output']>;
+};
+
+/** update columns of table "user_schedule_swap" */
+export enum User_Schedule_Swap_Update_Column {
+  /** column name */
+  ReplacementSectionId = 'replacement_section_id',
+  /** column name */
+  SourceSectionId = 'source_section_id',
+  /** column name */
+  UserId = 'user_id',
+}
+
+export type User_Schedule_Swap_Updates = {
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<User_Schedule_Swap_Inc_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<User_Schedule_Swap_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: User_Schedule_Swap_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type User_Schedule_Swap_Var_Pop_Fields = {
+  __typename?: 'user_schedule_swap_var_pop_fields';
+  replacement_section_id?: Maybe<Scalars['Float']['output']>;
+  source_section_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type User_Schedule_Swap_Var_Samp_Fields = {
+  __typename?: 'user_schedule_swap_var_samp_fields';
+  replacement_section_id?: Maybe<Scalars['Float']['output']>;
+  source_section_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type User_Schedule_Swap_Variance_Fields = {
+  __typename?: 'user_schedule_swap_variance_fields';
+  replacement_section_id?: Maybe<Scalars['Float']['output']>;
+  source_section_id?: Maybe<Scalars['Float']['output']>;
+  user_id?: Maybe<Scalars['Float']['output']>;
 };
 
 /** update columns of table "user_schedule" */
@@ -11927,6 +12291,39 @@ export type UpsertLikedReviewMutation = {
   insert_review: { returning: Array<{ id: number; liked: any }> } | null;
 };
 
+export type UpsertScheduleSwapMutationVariables = Exact<{
+  userId: number;
+  sourceSectionId: number;
+  replacementSectionId: number;
+}>;
+
+export type UpsertScheduleSwapMutation = {
+  insert_user_schedule_swap_one: {
+    user_id: number;
+    source_section_id: number;
+  } | null;
+};
+
+export type DeleteScheduleSwapMutationVariables = Exact<{
+  userId: number;
+  sourceSectionId: number;
+}>;
+
+export type DeleteScheduleSwapMutation = {
+  delete_user_schedule_swap_by_pk: {
+    user_id: number;
+    source_section_id: number;
+  } | null;
+};
+
+export type ClearScheduleSwapsMutationVariables = Exact<{
+  userId: number;
+}>;
+
+export type ClearScheduleSwapsMutation = {
+  delete_user_schedule_swap: { affected_rows: number } | null;
+};
+
 export type InsertSectionSubscriptionMutationVariables = Exact<{
   section_id?: number | null | undefined;
   user_id?: number | null | undefined;
@@ -12216,6 +12613,24 @@ export type Refetch_Prof_Review_UpvoteQueryVariables = Exact<{
 
 export type Refetch_Prof_Review_UpvoteQuery = {
   review: Array<ReviewVoteCountsFragment>;
+};
+
+export type GetScheduleSwapsQueryVariables = Exact<{
+  userId: number;
+  termIds: Array<number> | number;
+}>;
+
+export type GetScheduleSwapsQuery = {
+  user_schedule_swap: Array<{
+    user_id: number;
+    source_section_id: number;
+    replacement_section_id: number;
+    source_schedule: {
+      user_id: number;
+      section: { id: number; term_id: number };
+    };
+    replacement_section: SwapCourseSectionFragment;
+  }>;
 };
 
 export type GetUserQueryVariables = Exact<{
@@ -12936,6 +13351,178 @@ export type UpsertLikedReviewMutationResult =
 export type UpsertLikedReviewMutationOptions = Apollo.BaseMutationOptions<
   UpsertLikedReviewMutation,
   UpsertLikedReviewMutationVariables
+>;
+export const UpsertScheduleSwapDocument = gql`
+  mutation upsertScheduleSwap(
+    $userId: Int!
+    $sourceSectionId: Int!
+    $replacementSectionId: Int!
+  ) {
+    insert_user_schedule_swap_one(
+      object: {
+        user_id: $userId
+        source_section_id: $sourceSectionId
+        replacement_section_id: $replacementSectionId
+      }
+      on_conflict: {
+        constraint: user_schedule_swap_pkey
+        update_columns: [replacement_section_id]
+      }
+    ) {
+      user_id
+      source_section_id
+    }
+  }
+`;
+export type UpsertScheduleSwapMutationFn = Apollo.MutationFunction<
+  UpsertScheduleSwapMutation,
+  UpsertScheduleSwapMutationVariables
+>;
+
+/**
+ * __useUpsertScheduleSwapMutation__
+ *
+ * To run a mutation, you first call `useUpsertScheduleSwapMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpsertScheduleSwapMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [upsertScheduleSwapMutation, { data, loading, error }] = useUpsertScheduleSwapMutation({
+ *   variables: {
+ *      userId: // value for 'userId'
+ *      sourceSectionId: // value for 'sourceSectionId'
+ *      replacementSectionId: // value for 'replacementSectionId'
+ *   },
+ * });
+ */
+export function useUpsertScheduleSwapMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpsertScheduleSwapMutation,
+    UpsertScheduleSwapMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    UpsertScheduleSwapMutation,
+    UpsertScheduleSwapMutationVariables
+  >(UpsertScheduleSwapDocument, options);
+}
+export type UpsertScheduleSwapMutationHookResult = ReturnType<
+  typeof useUpsertScheduleSwapMutation
+>;
+export type UpsertScheduleSwapMutationResult =
+  Apollo.MutationResult<UpsertScheduleSwapMutation>;
+export type UpsertScheduleSwapMutationOptions = Apollo.BaseMutationOptions<
+  UpsertScheduleSwapMutation,
+  UpsertScheduleSwapMutationVariables
+>;
+export const DeleteScheduleSwapDocument = gql`
+  mutation deleteScheduleSwap($userId: Int!, $sourceSectionId: Int!) {
+    delete_user_schedule_swap_by_pk(
+      user_id: $userId
+      source_section_id: $sourceSectionId
+    ) {
+      user_id
+      source_section_id
+    }
+  }
+`;
+export type DeleteScheduleSwapMutationFn = Apollo.MutationFunction<
+  DeleteScheduleSwapMutation,
+  DeleteScheduleSwapMutationVariables
+>;
+
+/**
+ * __useDeleteScheduleSwapMutation__
+ *
+ * To run a mutation, you first call `useDeleteScheduleSwapMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteScheduleSwapMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteScheduleSwapMutation, { data, loading, error }] = useDeleteScheduleSwapMutation({
+ *   variables: {
+ *      userId: // value for 'userId'
+ *      sourceSectionId: // value for 'sourceSectionId'
+ *   },
+ * });
+ */
+export function useDeleteScheduleSwapMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    DeleteScheduleSwapMutation,
+    DeleteScheduleSwapMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    DeleteScheduleSwapMutation,
+    DeleteScheduleSwapMutationVariables
+  >(DeleteScheduleSwapDocument, options);
+}
+export type DeleteScheduleSwapMutationHookResult = ReturnType<
+  typeof useDeleteScheduleSwapMutation
+>;
+export type DeleteScheduleSwapMutationResult =
+  Apollo.MutationResult<DeleteScheduleSwapMutation>;
+export type DeleteScheduleSwapMutationOptions = Apollo.BaseMutationOptions<
+  DeleteScheduleSwapMutation,
+  DeleteScheduleSwapMutationVariables
+>;
+export const ClearScheduleSwapsDocument = gql`
+  mutation clearScheduleSwaps($userId: Int!) {
+    delete_user_schedule_swap(where: { user_id: { _eq: $userId } }) {
+      affected_rows
+    }
+  }
+`;
+export type ClearScheduleSwapsMutationFn = Apollo.MutationFunction<
+  ClearScheduleSwapsMutation,
+  ClearScheduleSwapsMutationVariables
+>;
+
+/**
+ * __useClearScheduleSwapsMutation__
+ *
+ * To run a mutation, you first call `useClearScheduleSwapsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useClearScheduleSwapsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [clearScheduleSwapsMutation, { data, loading, error }] = useClearScheduleSwapsMutation({
+ *   variables: {
+ *      userId: // value for 'userId'
+ *   },
+ * });
+ */
+export function useClearScheduleSwapsMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    ClearScheduleSwapsMutation,
+    ClearScheduleSwapsMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    ClearScheduleSwapsMutation,
+    ClearScheduleSwapsMutationVariables
+  >(ClearScheduleSwapsDocument, options);
+}
+export type ClearScheduleSwapsMutationHookResult = ReturnType<
+  typeof useClearScheduleSwapsMutation
+>;
+export type ClearScheduleSwapsMutationResult =
+  Apollo.MutationResult<ClearScheduleSwapsMutation>;
+export type ClearScheduleSwapsMutationOptions = Apollo.BaseMutationOptions<
+  ClearScheduleSwapsMutation,
+  ClearScheduleSwapsMutationVariables
 >;
 export const InsertSectionSubscriptionDocument = gql`
   mutation insertSectionSubscription($section_id: Int, $user_id: Int) {
@@ -15355,6 +15942,128 @@ export type Refetch_Prof_Review_UpvoteSuspenseQueryHookResult = ReturnType<
 export type Refetch_Prof_Review_UpvoteQueryResult = Apollo.QueryResult<
   Refetch_Prof_Review_UpvoteQuery,
   Refetch_Prof_Review_UpvoteQueryVariables
+>;
+export const GetScheduleSwapsDocument = gql`
+  query getScheduleSwaps($userId: Int!, $termIds: [Int!]!) {
+    user_schedule_swap(
+      where: {
+        user_id: { _eq: $userId }
+        source_schedule: { section: { term_id: { _in: $termIds } } }
+      }
+    ) {
+      user_id
+      source_section_id
+      replacement_section_id
+      source_schedule {
+        user_id
+        section {
+          id
+          term_id
+        }
+      }
+      replacement_section {
+        ...SwapCourseSection
+      }
+    }
+  }
+  ${SwapCourseSectionFragmentDoc}
+`;
+
+/**
+ * __useGetScheduleSwapsQuery__
+ *
+ * To run a query within a React component, call `useGetScheduleSwapsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetScheduleSwapsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetScheduleSwapsQuery({
+ *   variables: {
+ *      userId: // value for 'userId'
+ *      termIds: // value for 'termIds'
+ *   },
+ * });
+ */
+export function useGetScheduleSwapsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetScheduleSwapsQuery,
+    GetScheduleSwapsQueryVariables
+  > &
+    (
+      | { variables: GetScheduleSwapsQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetScheduleSwapsQuery, GetScheduleSwapsQueryVariables>(
+    GetScheduleSwapsDocument,
+    options,
+  );
+}
+export function useGetScheduleSwapsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetScheduleSwapsQuery,
+    GetScheduleSwapsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetScheduleSwapsQuery,
+    GetScheduleSwapsQueryVariables
+  >(GetScheduleSwapsDocument, options);
+}
+// @ts-ignore
+export function useGetScheduleSwapsSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GetScheduleSwapsQuery,
+    GetScheduleSwapsQueryVariables
+  >,
+): Apollo.UseSuspenseQueryResult<
+  GetScheduleSwapsQuery,
+  GetScheduleSwapsQueryVariables
+>;
+export function useGetScheduleSwapsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetScheduleSwapsQuery,
+        GetScheduleSwapsQueryVariables
+      >,
+): Apollo.UseSuspenseQueryResult<
+  GetScheduleSwapsQuery | undefined,
+  GetScheduleSwapsQueryVariables
+>;
+export function useGetScheduleSwapsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetScheduleSwapsQuery,
+        GetScheduleSwapsQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetScheduleSwapsQuery,
+    GetScheduleSwapsQueryVariables
+  >(GetScheduleSwapsDocument, options);
+}
+export type GetScheduleSwapsQueryHookResult = ReturnType<
+  typeof useGetScheduleSwapsQuery
+>;
+export type GetScheduleSwapsLazyQueryHookResult = ReturnType<
+  typeof useGetScheduleSwapsLazyQuery
+>;
+export type GetScheduleSwapsSuspenseQueryHookResult = ReturnType<
+  typeof useGetScheduleSwapsSuspenseQuery
+>;
+export type GetScheduleSwapsQueryResult = Apollo.QueryResult<
+  GetScheduleSwapsQuery,
+  GetScheduleSwapsQueryVariables
 >;
 export const GetUserDocument = gql`
   query getUser($id: Int) {

--- a/src/graphql/__tests__/cache.test.ts
+++ b/src/graphql/__tests__/cache.test.ts
@@ -59,6 +59,16 @@ describe('Apollo InMemoryCache normalization (typePolicies keyFields)', () => {
     ).toBe('user_schedule:{"user_id":5,"section":{"id":99}}');
   });
 
+  it('keys user_schedule_swap by user_id + source_section_id', () => {
+    expect(
+      cache.identify({
+        __typename: 'user_schedule_swap',
+        user_id: 5,
+        source_section_id: 99,
+      }),
+    ).toBe('user_schedule_swap:{"user_id":5,"source_section_id":99}');
+  });
+
   it('falls back to the default id heuristic for ordinary typenames', () => {
     expect(cache.identify({ __typename: 'course', id: 123 })).toBe(
       'course:123',

--- a/src/graphql/apollo.js
+++ b/src/graphql/apollo.js
@@ -80,6 +80,9 @@ export const cache = new InMemoryCache({
       // `section`/`id` as subfields of the scalar `user_id`.
       keyFields: ['user_id', 'section', ['id']],
     },
+    user_schedule_swap: {
+      keyFields: ['user_id', 'source_section_id'],
+    },
   },
 });
 

--- a/src/graphql/mutations/ScheduleSwap.tsx
+++ b/src/graphql/mutations/ScheduleSwap.tsx
@@ -1,0 +1,44 @@
+import { gql } from '@apollo/client';
+
+export const UPSERT_SCHEDULE_SWAP = gql`
+  mutation upsertScheduleSwap(
+    $userId: Int!
+    $sourceSectionId: Int!
+    $replacementSectionId: Int!
+  ) {
+    insert_user_schedule_swap_one(
+      object: {
+        user_id: $userId
+        source_section_id: $sourceSectionId
+        replacement_section_id: $replacementSectionId
+      }
+      on_conflict: {
+        constraint: user_schedule_swap_pkey
+        update_columns: [replacement_section_id]
+      }
+    ) {
+      user_id
+      source_section_id
+    }
+  }
+`;
+
+export const DELETE_SCHEDULE_SWAP = gql`
+  mutation deleteScheduleSwap($userId: Int!, $sourceSectionId: Int!) {
+    delete_user_schedule_swap_by_pk(
+      user_id: $userId
+      source_section_id: $sourceSectionId
+    ) {
+      user_id
+      source_section_id
+    }
+  }
+`;
+
+export const CLEAR_SCHEDULE_SWAPS = gql`
+  mutation clearScheduleSwaps($userId: Int!) {
+    delete_user_schedule_swap(where: { user_id: { _eq: $userId } }) {
+      affected_rows
+    }
+  }
+`;

--- a/src/graphql/queries/course/SwapCourse.tsx
+++ b/src/graphql/queries/course/SwapCourse.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client';
 
-const SwapCourseSectionFragment = gql`
+export const SwapCourseSectionFragment = gql`
   fragment SwapCourseSection on course_section {
     id
     section_name

--- a/src/graphql/queries/user/ScheduleSwap.tsx
+++ b/src/graphql/queries/user/ScheduleSwap.tsx
@@ -1,0 +1,29 @@
+import { gql } from '@apollo/client';
+
+import { SwapCourseSectionFragment } from 'graphql/queries/course/SwapCourse';
+
+export const GET_SCHEDULE_SWAPS = gql`
+  query getScheduleSwaps($userId: Int!, $termIds: [Int!]!) {
+    user_schedule_swap(
+      where: {
+        user_id: { _eq: $userId }
+        source_schedule: { section: { term_id: { _in: $termIds } } }
+      }
+    ) {
+      user_id
+      source_section_id
+      replacement_section_id
+      source_schedule {
+        user_id
+        section {
+          id
+          term_id
+        }
+      }
+      replacement_section {
+        ...SwapCourseSection
+      }
+    }
+  }
+  ${SwapCourseSectionFragment}
+`;

--- a/src/pages/swapPage/SwapCalendar.tsx
+++ b/src/pages/swapPage/SwapCalendar.tsx
@@ -40,6 +40,10 @@ import ScheduleSwapPanel, {
   SwapCandidateCourse,
   SwapPreview,
 } from './ScheduleSwapPanel';
+import useScheduleSwaps, {
+  DisplayedTerm,
+  PlannedSwap,
+} from './useScheduleSwaps';
 
 const DAY_LETTERS = ['M', 'T', 'W', 'Th', 'F'];
 const DAY_LABELS = ['MON', 'TUE', 'WED', 'THU', 'FRI'];
@@ -207,30 +211,62 @@ const buildPreviewEvents = (
 
 type ScheduleEntry = UserScheduleFragment['schedule'][number];
 
-// Bridge a fetched swap section into the schedule-entry shape used for
-// client-side temporary swaps. The fragment is a superset of the schedule
-// entry's section selection, so this is a plain (cast-free) re-wrap.
+// Bridge a fetched replacement into the schedule-entry shape used by the
+// calendar overlay. The fragment is a superset of the schedule entry's section
+// selection, so this is a plain (cast-free) re-wrap.
 const toScheduleEntry = (
   section: SwapCourseSectionFragment,
   userId: number,
 ): ScheduleEntry => ({ user_id: userId, section });
 
+/**
+ * Enrolled sections for one term, with the user's saved swap plan overlaid.
+ * The imported schedule remains the base and is never mutated.
+ */
+const applyPlannedSwaps = (
+  schedule: UserScheduleFragment['schedule'],
+  termCode: number,
+  plannedSwaps: PlannedSwap[],
+): UserScheduleFragment['schedule'] => {
+  const base = schedule.filter((entry) => entry.section.term_id === termCode);
+  const replacementBySourceId = new Map(
+    plannedSwaps.map(({ sourceSectionId, replacementSection }) => [
+      sourceSectionId,
+      replacementSection,
+    ]),
+  );
+
+  return base.map((entry) => {
+    const replacement = replacementBySourceId.get(entry.section.id);
+    return replacement ? toScheduleEntry(replacement, entry.user_id) : entry;
+  });
+};
+
 type SwapCalendarProps = {
   schedule: UserScheduleFragment['schedule'];
   /** Renders a non-interactive sample schedule (logged-out lock state). */
   demoMode?: boolean;
+  /** Keeps saved swap plans isolated to the signed-in user. */
+  userId?: number | null;
 };
 
-const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
+const SwapCalendar = ({
+  schedule,
+  demoMode = false,
+  userId = null,
+}: SwapCalendarProps) => {
   const thisTermCode = getCurrentTermCode();
   const nextTermCode = getNextTermCode();
   const thisTermLabel = termCodeToDate(thisTermCode);
   const nextTermLabel = termCodeToDate(nextTermCode);
 
-  const [selectedTerm, setSelectedTerm] = useState<string>(() => {
-    const { thisHasData, nextHasData } = getDisplayedTermPresence(schedule);
-    return !nextHasData || thisHasData ? thisTermLabel : nextTermLabel;
-  });
+  const { thisHasData, nextHasData } = getDisplayedTermPresence(schedule);
+  const defaultSelectedTerm =
+    !nextHasData || thisHasData ? DisplayedTerm.Current : DisplayedTerm.Next;
+  const [selectedTerm, setSelectedTerm] =
+    useState<DisplayedTerm>(defaultSelectedTerm);
+  const selectedTermCode =
+    selectedTerm === DisplayedTerm.Next ? nextTermCode : thisTermCode;
   // The clicked calendar block's course + section type (e.g. CS 240 / LEC).
   // Selection, the panel's section list, and swapping are all scoped to this
   // one course+type pair.
@@ -243,26 +279,30 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
   const [selectedSwapCourseCode, setSelectedSwapCourseCode] = useState<
     string | null
   >(null);
-  // Temporary client-side section swaps, keyed by term label. A swap replaces
-  // the matching schedule entry in React state only — refreshing the page
-  // restores the original schedule (no persistence, no mutations).
-  const [overriddenByTerm, setOverriddenByTerm] = useState<
-    Record<string, UserScheduleFragment['schedule']>
-  >({});
+
+  const { plannedSwapsByTerm, planSwap, clearSwaps, isPlanSettled } =
+    useScheduleSwaps({
+      userId,
+      demoMode,
+      currentTermCode: thisTermCode,
+      nextTermCode,
+    });
 
   useEffect(() => {
     setSelectedSwapCourseCode(null);
     setHoveredSection(null);
   }, [selectedCourseCode, selectedSectionType]);
 
-  const selectedTermCode =
-    selectedTerm === nextTermLabel ? nextTermCode : thisTermCode;
-  // Effective schedule for the term: temporary swaps take precedence.
+  // Effective schedule for the term: persisted swaps overlay the original
+  // imported schedule without modifying it.
   const termSections = useMemo(
     () =>
-      overriddenByTerm[selectedTerm] ??
-      schedule.filter((entry) => entry.section.term_id === selectedTermCode),
-    [overriddenByTerm, schedule, selectedTerm, selectedTermCode],
+      applyPlannedSwaps(
+        schedule,
+        selectedTermCode,
+        plannedSwapsByTerm[selectedTerm] ?? [],
+      ),
+    [schedule, selectedTerm, selectedTermCode, plannedSwapsByTerm],
   );
 
   // Distinct courses in the user's schedule for this term, for the left
@@ -421,13 +461,17 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
     [],
   );
 
-  // Term overrides persist while the page lives — only a refresh resets them.
-  const handleTermChange = useCallback((termId: number) => {
-    setSelectedTerm(termCodeToDate(termId));
-    setSelection(null);
-    setSelectedSwapCourseCode(null);
-    setHoveredSection(null);
-  }, []);
+  const handleTermChange = useCallback(
+    (termId: number) => {
+      setSelectedTerm(
+        termId === nextTermCode ? DisplayedTerm.Next : DisplayedTerm.Current,
+      );
+      setSelection(null);
+      setSelectedSwapCourseCode(null);
+      setHoveredSection(null);
+    },
+    [nextTermCode],
+  );
 
   const handleCourseChange = useCallback((courseCode: string | null) => {
     setSelectedSwapCourseCode(courseCode);
@@ -447,8 +491,15 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
     [termSections],
   );
 
-  // Temporarily swap a section into the schedule (React state only). The new
-  // section replaces the entry matching the selected course + section type
+  const handleResetSwaps = () => {
+    clearSwaps();
+    setSelection(null);
+    setSelectedSwapCourseCode(null);
+    setHoveredSection(null);
+  };
+
+  // Save a section in the user's swap plan. The new section replaces the
+  // entry matching the selected course + section type
   // (LEC↔LEC, TUT↔TUT) — the panel only offers same-type candidates.
   const handleSwitchSection = useCallback(
     (sectionId: number) => {
@@ -463,12 +514,13 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
       );
       if (replaceIndex === -1) return;
 
-      const next = [...base];
-      next[replaceIndex] = toScheduleEntry(
-        newSection,
-        base[replaceIndex].user_id,
+      const currentSectionId = base[replaceIndex].section.id;
+      const existingSwap = (plannedSwapsByTerm[selectedTerm] ?? []).find(
+        ({ replacementSectionId }) => replacementSectionId === currentSectionId,
       );
-      setOverriddenByTerm((prev) => ({ ...prev, [selectedTerm]: next }));
+      const sourceSectionId = existingSwap?.sourceSectionId ?? currentSectionId;
+
+      planSwap(selectedTerm, sourceSectionId, newSection);
       setHoveredSection(null);
       if (newSection.course.code !== selection.courseCode) {
         // Follow the swapped-in course (keeping the selected section type);
@@ -480,7 +532,14 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
         });
       }
     },
-    [swapSections, termSections, selection, selectedTerm],
+    [
+      planSwap,
+      plannedSwapsByTerm,
+      selectedTerm,
+      selection,
+      swapSections,
+      termSections,
+    ],
   );
 
   const events = useMemo(
@@ -511,7 +570,7 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
     { id: nextTermCode, label: nextTermLabel },
   ];
   const swapTargetCode = selectedSwapCourseCode ?? selectedCourseCode;
-  const hasSwaps = Object.keys(overriddenByTerm).length > 0;
+  const hasSwaps = Object.keys(plannedSwapsByTerm).length > 0;
 
   return (
     <div className="relative z-0 w-screen animate-fade-in">
@@ -585,13 +644,16 @@ const SwapCalendar = ({ schedule, demoMode = false }: SwapCalendarProps) => {
                 </span>
               )}
               {hasSwaps && (
-                // Swaps live only in React state, so a refresh restores the
-                // real schedule.
                 <button
                   aria-label="Reset swapped sections"
-                  title="Reset swapped sections"
-                  className="ml-auto flex shrink-0 cursor-pointer items-center gap-1 border-none bg-transparent p-0 font-inter text-xs font-semibold text-dark2 outline-none transition-colors hover:text-dark1"
-                  onClick={() => window.location.reload()}
+                  className="ml-auto flex shrink-0 cursor-pointer items-center gap-1 border-none bg-transparent p-0 font-inter text-xs font-semibold text-dark2 outline-none transition-colors hover:text-dark1 disabled:cursor-default disabled:text-dark3 disabled:hover:text-dark3"
+                  disabled={!isPlanSettled}
+                  onClick={handleResetSwaps}
+                  title={
+                    isPlanSettled
+                      ? 'Reset swapped sections'
+                      : 'Applying your saved swaps…'
+                  }
                   type="button"
                 >
                   <RotateCcw aria-hidden="true" size={14} />

--- a/src/pages/swapPage/SwapPage.tsx
+++ b/src/pages/swapPage/SwapPage.tsx
@@ -49,6 +49,14 @@ const SwapPage = () => {
   // Logged-out visitors see a non-interactive sample schedule behind the
   // login lock card instead of an empty grid.
   const isDemo = !isLoggedIn && !hasDisplayedTermClasses;
+  const displayedSchedule = isDemo ? DEMO_SCHEDULE : schedule;
+  const scheduleSectionKey = displayedSchedule
+    .map(({ section }) => section.id)
+    .sort((a, b) => a - b)
+    .join(',');
+  const swapCalendarKey = `${
+    isDemo ? 'demo' : user?.id ?? 'anonymous'
+  }:${scheduleSectionKey}`;
 
   useEffect(() => {
     if (!hasDisplayedTermClasses) {
@@ -100,8 +108,13 @@ const SwapPage = () => {
         )}
       </Helmet>
       <SwapCalendar
-        schedule={isDemo ? DEMO_SCHEDULE : schedule}
+        // Drop ephemeral selection/hover state when the user or their imported
+        // base schedule changes. The backend foreign key removes any saved
+        // swap whose source schedule row no longer exists.
+        key={swapCalendarKey}
+        schedule={displayedSchedule}
         demoMode={isDemo}
+        userId={user?.id ?? null}
       />
       <div style={{ display: 'flex', justifyContent: 'center' }}>
         <div

--- a/src/pages/swapPage/useScheduleSwaps.test.ts
+++ b/src/pages/swapPage/useScheduleSwaps.test.ts
@@ -1,0 +1,465 @@
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import {
+  GetScheduleSwapsQuery,
+  SwapCourseSectionFragment,
+} from 'generated/graphql';
+
+import { SCHEDULE_SWAP_ERROR } from 'constants/Messages';
+
+import useScheduleSwaps, { DisplayedTerm } from './useScheduleSwaps';
+
+const mockUseQuery = jest.fn();
+const mockUpsertScheduleSwap = jest.fn();
+const mockDeleteScheduleSwap = jest.fn();
+const mockClearScheduleSwaps = jest.fn();
+const mockToast = jest.fn();
+
+jest.mock('@apollo/client', () => ({
+  gql: (strings: TemplateStringsArray) => strings.join(''),
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: (document: string) => {
+    if (document.includes('mutation upsertScheduleSwap')) {
+      return [mockUpsertScheduleSwap];
+    }
+    if (document.includes('mutation deleteScheduleSwap')) {
+      return [mockDeleteScheduleSwap];
+    }
+    if (document.includes('mutation clearScheduleSwaps')) {
+      return [mockClearScheduleSwaps];
+    }
+    throw new Error(`Unexpected mutation: ${document}`);
+  },
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+const CURRENT_TERM = 1265;
+const NEXT_TERM = 1269;
+
+type HookArgs = {
+  userId: number | null;
+  demoMode: boolean;
+  currentTermCode: number;
+  nextTermCode: number;
+};
+
+type HookResult = ReturnType<typeof useScheduleSwaps>;
+
+/** Only identity is read from a newly selected replacement. */
+const fakeSection = (id: number): SwapCourseSectionFragment =>
+  ({ id } as SwapCourseSectionFragment);
+
+const savedSwap = (
+  userId: number,
+  sourceSectionId: number,
+  replacementSection: SwapCourseSectionFragment,
+  sourceTermId = CURRENT_TERM,
+): GetScheduleSwapsQuery['user_schedule_swap'][number] => ({
+  user_id: userId,
+  source_section_id: sourceSectionId,
+  replacement_section_id: replacementSection.id,
+  source_schedule: {
+    user_id: userId,
+    section: { id: sourceSectionId, term_id: sourceTermId },
+  },
+  replacement_section: replacementSection,
+});
+
+const defaultArgs = (userId: number | null = 42): HookArgs => ({
+  userId,
+  demoMode: false,
+  currentTermCode: CURRENT_TERM,
+  nextTermCode: NEXT_TERM,
+});
+
+const renderHook = (initialArgs: HookArgs) => {
+  const result: { current: HookResult | null } = { current: null };
+  let args = initialArgs;
+
+  const Test = () => {
+    result.current = useScheduleSwaps(args);
+    return null;
+  };
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root: Root;
+
+  act(() => {
+    root = createRoot(container);
+    root.render(React.createElement(Test));
+  });
+
+  return {
+    result: result as { current: HookResult },
+    rerender: (nextArgs: HookArgs) => {
+      args = nextArgs;
+      act(() => {
+        root.render(React.createElement(Test));
+      });
+    },
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+};
+
+const flushPromises = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe('useScheduleSwaps', () => {
+  const userId = 42;
+
+  beforeEach(() => {
+    mockUseQuery.mockReset();
+    mockUseQuery.mockReturnValue({
+      data: { user_schedule_swap: [] },
+      loading: false,
+      error: undefined,
+    });
+    mockUpsertScheduleSwap.mockReset();
+    mockUpsertScheduleSwap.mockResolvedValue({});
+    mockDeleteScheduleSwap.mockReset();
+    mockDeleteScheduleSwap.mockResolvedValue({});
+    mockClearScheduleSwaps.mockReset();
+    mockClearScheduleSwaps.mockResolvedValue({});
+    mockToast.mockReset();
+
+    // React 18 act() only flushes effects when this flag is set.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  it('restores backend swaps under the actual term of each source section', () => {
+    const currentReplacement = fakeSection(2001);
+    const nextReplacement = fakeSection(2002);
+    mockUseQuery.mockReturnValue({
+      data: {
+        user_schedule_swap: [
+          savedSwap(userId, 1001, currentReplacement),
+          savedSwap(userId, 1002, nextReplacement, NEXT_TERM),
+        ],
+      },
+      loading: false,
+      error: undefined,
+    });
+
+    const { result, unmount } = renderHook(defaultArgs());
+
+    expect(result.current.plannedSwapsByTerm).toEqual({
+      [DisplayedTerm.Current]: [
+        {
+          sourceSectionId: 1001,
+          replacementSectionId: 2001,
+          replacementSection: currentReplacement,
+        },
+      ],
+      [DisplayedTerm.Next]: [
+        {
+          sourceSectionId: 1002,
+          replacementSectionId: 2002,
+          replacementSection: nextReplacement,
+        },
+      ],
+    });
+    unmount();
+  });
+
+  it('ignores saved rows whose source is not in a displayed schedule term', () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        user_schedule_swap: [savedSwap(userId, 9999, fakeSection(2001), 1261)],
+      },
+      loading: false,
+      error: undefined,
+    });
+
+    const { result, unmount } = renderHook(defaultArgs());
+
+    expect(result.current.plannedSwapsByTerm).toEqual({});
+    unmount();
+  });
+
+  it('optimistically plans a swap and upserts its ID pair', async () => {
+    const replacement = fakeSection(2001);
+    const { result, unmount } = renderHook(defaultArgs());
+
+    act(() => {
+      result.current.planSwap(DisplayedTerm.Current, 1001, replacement);
+    });
+
+    expect(result.current.plannedSwapsByTerm).toEqual({
+      [DisplayedTerm.Current]: [
+        {
+          sourceSectionId: 1001,
+          replacementSectionId: 2001,
+          replacementSection: replacement,
+        },
+      ],
+    });
+    await flushPromises();
+    expect(mockUpsertScheduleSwap).toHaveBeenCalledWith({
+      variables: {
+        userId,
+        sourceSectionId: 1001,
+        replacementSectionId: 2001,
+      },
+    });
+    unmount();
+  });
+
+  it('preserves a choice made before the backend restore finishes', async () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    const hook = renderHook(defaultArgs());
+    const localReplacement = fakeSection(2001);
+
+    act(() => {
+      hook.result.current.planSwap(
+        DisplayedTerm.Current,
+        1001,
+        localReplacement,
+      );
+    });
+
+    mockUseQuery.mockReturnValue({
+      data: {
+        user_schedule_swap: [savedSwap(userId, 1001, fakeSection(3001))],
+      },
+      loading: false,
+      error: undefined,
+    });
+    hook.rerender(defaultArgs());
+
+    expect(hook.result.current.plannedSwapsByTerm).toEqual({
+      [DisplayedTerm.Current]: [
+        {
+          sourceSectionId: 1001,
+          replacementSectionId: 2001,
+          replacementSection: localReplacement,
+        },
+      ],
+    });
+    await flushPromises();
+    hook.unmount();
+  });
+
+  it('does not overwrite local state after the initial backend restore', () => {
+    const originalReplacement = fakeSection(2001);
+    mockUseQuery.mockReturnValue({
+      data: {
+        user_schedule_swap: [savedSwap(userId, 1001, originalReplacement)],
+      },
+      loading: false,
+      error: undefined,
+    });
+    const hook = renderHook(defaultArgs());
+    const localReplacement = fakeSection(2002);
+
+    act(() => {
+      hook.result.current.planSwap(
+        DisplayedTerm.Current,
+        1001,
+        localReplacement,
+      );
+    });
+
+    // A cache write or incidental refetch must not rewind a newer local choice.
+    mockUseQuery.mockReturnValue({
+      data: {
+        user_schedule_swap: [
+          {
+            ...savedSwap(userId, 1001, originalReplacement),
+            replacement_section_id: localReplacement.id,
+          },
+        ],
+      },
+      loading: false,
+      error: undefined,
+    });
+    hook.rerender(defaultArgs());
+
+    expect(hook.result.current.plannedSwapsByTerm).toEqual({
+      [DisplayedTerm.Current]: [
+        {
+          sourceSectionId: 1001,
+          replacementSectionId: 2002,
+          replacementSection: localReplacement,
+        },
+      ],
+    });
+    hook.unmount();
+  });
+
+  it('does not resurrect backend rows when reset wins a restore race', async () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    const hook = renderHook(defaultArgs());
+
+    act(() => hook.result.current.clearSwaps());
+
+    mockUseQuery.mockReturnValue({
+      data: {
+        user_schedule_swap: [savedSwap(userId, 1001, fakeSection(3001))],
+      },
+      loading: false,
+      error: undefined,
+    });
+    hook.rerender(defaultArgs());
+
+    expect(hook.result.current.plannedSwapsByTerm).toEqual({});
+    await flushPromises();
+    expect(mockClearScheduleSwaps).toHaveBeenCalledWith({
+      variables: { userId },
+    });
+    hook.unmount();
+  });
+
+  it('serializes rapid writes so their backend order matches the choices', async () => {
+    let resolveFirst: (() => void) | undefined;
+    mockUpsertScheduleSwap
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({});
+    const { result, unmount } = renderHook(defaultArgs());
+
+    act(() => {
+      result.current.planSwap(DisplayedTerm.Current, 1001, fakeSection(2001));
+      result.current.planSwap(DisplayedTerm.Current, 1001, fakeSection(2002));
+    });
+    await flushPromises();
+
+    expect(mockUpsertScheduleSwap).toHaveBeenCalledTimes(1);
+    resolveFirst?.();
+    await flushPromises();
+    expect(mockUpsertScheduleSwap).toHaveBeenCalledTimes(2);
+    expect(mockUpsertScheduleSwap.mock.calls[1][0]).toEqual({
+      variables: {
+        userId,
+        sourceSectionId: 1001,
+        replacementSectionId: 2002,
+      },
+    });
+    unmount();
+  });
+
+  it('reports a failed write and continues the mutation queue', async () => {
+    mockUpsertScheduleSwap
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({});
+    const { result, unmount } = renderHook(defaultArgs());
+
+    act(() => {
+      result.current.planSwap(DisplayedTerm.Current, 1001, fakeSection(2001));
+      result.current.planSwap(DisplayedTerm.Current, 1001, fakeSection(2002));
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(mockToast).toHaveBeenCalledWith(SCHEDULE_SWAP_ERROR);
+    expect(mockUpsertScheduleSwap).toHaveBeenCalledTimes(2);
+    expect(mockUpsertScheduleSwap.mock.calls[1][0]).toEqual({
+      variables: {
+        userId,
+        sourceSectionId: 1001,
+        replacementSectionId: 2002,
+      },
+    });
+    unmount();
+  });
+
+  it('reverting to the enrolled section deletes the persisted swap', async () => {
+    const replacement = fakeSection(2001);
+    mockUseQuery.mockReturnValue({
+      data: {
+        user_schedule_swap: [savedSwap(userId, 1001, replacement)],
+      },
+      loading: false,
+      error: undefined,
+    });
+    const { result, unmount } = renderHook(defaultArgs());
+
+    act(() => {
+      result.current.planSwap(DisplayedTerm.Current, 1001, fakeSection(1001));
+    });
+
+    expect(result.current.plannedSwapsByTerm).toEqual({});
+    await flushPromises();
+    expect(mockDeleteScheduleSwap).toHaveBeenCalledWith({
+      variables: { userId, sourceSectionId: 1001 },
+    });
+    unmount();
+  });
+
+  it('clears both the local overlay and all persisted swaps', async () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        user_schedule_swap: [savedSwap(userId, 1001, fakeSection(2001))],
+      },
+      loading: false,
+      error: undefined,
+    });
+    const { result, unmount } = renderHook(defaultArgs());
+
+    act(() => result.current.clearSwaps());
+
+    expect(result.current.plannedSwapsByTerm).toEqual({});
+    await flushPromises();
+    expect(mockClearScheduleSwaps).toHaveBeenCalledWith({
+      variables: { userId },
+    });
+    unmount();
+  });
+
+  it('keeps demo swaps in memory without writing to the backend', async () => {
+    const { result, unmount } = renderHook({
+      ...defaultArgs(),
+      demoMode: true,
+    });
+
+    act(() => {
+      result.current.planSwap(DisplayedTerm.Current, 1001, fakeSection(2001));
+    });
+    await flushPromises();
+
+    expect(mockUseQuery.mock.calls[0][1]).toMatchObject({ skip: true });
+    expect(mockUpsertScheduleSwap).not.toHaveBeenCalled();
+    expect(mockDeleteScheduleSwap).not.toHaveBeenCalled();
+    expect(mockClearScheduleSwaps).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('settles a failed restore and tells the user persistence is unavailable', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: new Error('network down'),
+    });
+
+    const { result, unmount } = renderHook(defaultArgs());
+
+    expect(result.current.isPlanSettled).toBe(true);
+    expect(mockToast).toHaveBeenCalledWith(SCHEDULE_SWAP_ERROR);
+    unmount();
+  });
+});

--- a/src/pages/swapPage/useScheduleSwaps.ts
+++ b/src/pages/swapPage/useScheduleSwaps.ts
@@ -1,0 +1,266 @@
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'react-toastify';
+import { useMutation, useQuery } from '@apollo/client';
+import {
+  ClearScheduleSwapsMutation,
+  ClearScheduleSwapsMutationVariables,
+  DeleteScheduleSwapMutation,
+  DeleteScheduleSwapMutationVariables,
+  GetScheduleSwapsQuery,
+  GetScheduleSwapsQueryVariables,
+  SwapCourseSectionFragment,
+  UpsertScheduleSwapMutation,
+  UpsertScheduleSwapMutationVariables,
+} from 'generated/graphql';
+
+import { SCHEDULE_SWAP_ERROR } from 'constants/Messages';
+import {
+  CLEAR_SCHEDULE_SWAPS,
+  DELETE_SCHEDULE_SWAP,
+  UPSERT_SCHEDULE_SWAP,
+} from 'graphql/mutations/ScheduleSwap';
+import { GET_SCHEDULE_SWAPS } from 'graphql/queries/user/ScheduleSwap';
+
+/** The two term tabs the swap calendar shows. */
+export enum DisplayedTerm {
+  Current = 'current',
+  Next = 'next',
+}
+
+/** One planned swap and the current replacement data returned by the backend. */
+export type PlannedSwap = {
+  sourceSectionId: number;
+  replacementSectionId: number;
+  replacementSection: SwapCourseSectionFragment;
+};
+
+type SwapsByTerm = Partial<Record<DisplayedTerm, PlannedSwap[]>>;
+type ScheduleSwapRow = GetScheduleSwapsQuery['user_schedule_swap'][number];
+
+type PendingSwapChange = {
+  term: DisplayedTerm;
+  replacementSection: SwapCourseSectionFragment | null;
+};
+
+const displayedTerms = Object.values(DisplayedTerm);
+
+/**
+ * Replaces one source section in the in-memory overlay. A null replacement
+ * means the user reverted that source to the enrolled section.
+ */
+const withSwapChange = (
+  swapsByTerm: SwapsByTerm,
+  term: DisplayedTerm,
+  sourceSectionId: number,
+  replacementSection: SwapCourseSectionFragment | null,
+): SwapsByTerm => {
+  const next: SwapsByTerm = {};
+
+  for (const displayedTerm of displayedTerms) {
+    const remaining = (swapsByTerm[displayedTerm] ?? []).filter(
+      (swap) => swap.sourceSectionId !== sourceSectionId,
+    );
+    if (remaining.length > 0) next[displayedTerm] = remaining;
+  }
+
+  if (replacementSection !== null) {
+    next[term] = [
+      ...(next[term] ?? []),
+      {
+        sourceSectionId,
+        replacementSectionId: replacementSection.id,
+        replacementSection,
+      },
+    ];
+  }
+
+  return next;
+};
+
+/** Group persisted rows by the actual term of their enrolled source section. */
+const groupScheduleSwaps = (
+  rows: ScheduleSwapRow[],
+  currentTermCode: number,
+  nextTermCode: number,
+): SwapsByTerm => {
+  const grouped: SwapsByTerm = {};
+
+  for (const row of rows) {
+    const sourceTerm = row.source_schedule.section.term_id;
+    const term =
+      sourceTerm === currentTermCode
+        ? DisplayedTerm.Current
+        : sourceTerm === nextTermCode
+        ? DisplayedTerm.Next
+        : null;
+    if (term === null) continue;
+
+    const plannedSwap: PlannedSwap = {
+      sourceSectionId: row.source_section_id,
+      replacementSectionId: row.replacement_section_id,
+      replacementSection: row.replacement_section,
+    };
+    grouped[term] = [...(grouped[term] ?? []), plannedSwap];
+  }
+
+  return grouped;
+};
+
+type UseScheduleSwapsArgs = {
+  userId: number | null;
+  demoMode: boolean;
+  currentTermCode: number;
+  nextTermCode: number;
+};
+
+/**
+ * Owns the swap overlay while persisting each source/replacement pair in the
+ * backend. The imported schedule remains untouched; saved swaps are restored
+ * with fresh section data whenever the page is opened.
+ */
+const useScheduleSwaps = ({
+  userId,
+  demoMode,
+  currentTermCode,
+  nextTermCode,
+}: UseScheduleSwapsArgs) => {
+  const persistenceEnabled = !demoMode && userId !== null;
+  const [swapsByTerm, setSwapsByTerm] = useState<SwapsByTerm>({});
+  const restoredRef = useRef(false);
+  const changesBeforeRestoreRef = useRef<Map<number, PendingSwapChange>>(
+    new Map(),
+  );
+  const clearedBeforeRestoreRef = useRef(false);
+  // Hasura mutations are serialized so rapid choices for the same source
+  // cannot arrive out of order and leave an older replacement in the backend.
+  const mutationQueueRef = useRef<Promise<void>>(Promise.resolve());
+
+  const { data, loading, error } = useQuery<
+    GetScheduleSwapsQuery,
+    GetScheduleSwapsQueryVariables
+  >(GET_SCHEDULE_SWAPS, {
+    variables: {
+      userId: userId ?? 0,
+      termIds: [currentTermCode, nextTermCode],
+    },
+    skip: !persistenceEnabled,
+    fetchPolicy: 'network-only',
+  });
+
+  const [upsertScheduleSwap] = useMutation<
+    UpsertScheduleSwapMutation,
+    UpsertScheduleSwapMutationVariables
+  >(UPSERT_SCHEDULE_SWAP);
+  const [deleteScheduleSwap] = useMutation<
+    DeleteScheduleSwapMutation,
+    DeleteScheduleSwapMutationVariables
+  >(DELETE_SCHEDULE_SWAP);
+  const [clearScheduleSwaps] = useMutation<
+    ClearScheduleSwapsMutation,
+    ClearScheduleSwapsMutationVariables
+  >(CLEAR_SCHEDULE_SWAPS);
+
+  const enqueueMutation = (mutation: () => Promise<unknown>) => {
+    mutationQueueRef.current = mutationQueueRef.current.then(async () => {
+      try {
+        await mutation();
+      } catch {
+        toast(SCHEDULE_SWAP_ERROR);
+      }
+    });
+  };
+
+  // Restore the backend plan once. If the user made a choice before the query
+  // returned, replay that choice over the response instead of losing it.
+  useEffect(() => {
+    if (restoredRef.current) return;
+    if (!persistenceEnabled) {
+      restoredRef.current = true;
+      return;
+    }
+    if (!data && !error) return;
+
+    let restored = clearedBeforeRestoreRef.current
+      ? {}
+      : groupScheduleSwaps(
+          data?.user_schedule_swap ?? [],
+          currentTermCode,
+          nextTermCode,
+        );
+    for (const [sourceSectionId, change] of Array.from(
+      changesBeforeRestoreRef.current.entries(),
+    )) {
+      restored = withSwapChange(
+        restored,
+        change.term,
+        sourceSectionId,
+        change.replacementSection,
+      );
+    }
+
+    setSwapsByTerm(restored);
+    changesBeforeRestoreRef.current.clear();
+    clearedBeforeRestoreRef.current = false;
+    restoredRef.current = true;
+  }, [currentTermCode, data, error, nextTermCode, persistenceEnabled]);
+
+  useEffect(() => {
+    if (error) toast(SCHEDULE_SWAP_ERROR);
+  }, [error]);
+
+  const planSwap = (
+    term: DisplayedTerm,
+    sourceSectionId: number,
+    replacementSection: SwapCourseSectionFragment,
+  ) => {
+    const isReverting = replacementSection.id === sourceSectionId;
+    const nextReplacement = isReverting ? null : replacementSection;
+
+    setSwapsByTerm((prev) =>
+      withSwapChange(prev, term, sourceSectionId, nextReplacement),
+    );
+
+    if (!restoredRef.current) {
+      changesBeforeRestoreRef.current.set(sourceSectionId, {
+        term,
+        replacementSection: nextReplacement,
+      });
+    }
+    if (!persistenceEnabled || userId === null) return;
+
+    if (isReverting) {
+      enqueueMutation(() =>
+        deleteScheduleSwap({ variables: { userId, sourceSectionId } }),
+      );
+      return;
+    }
+
+    enqueueMutation(() =>
+      upsertScheduleSwap({
+        variables: {
+          userId,
+          sourceSectionId,
+          replacementSectionId: replacementSection.id,
+        },
+      }),
+    );
+  };
+
+  const clearSwaps = () => {
+    setSwapsByTerm({});
+    changesBeforeRestoreRef.current.clear();
+    if (!restoredRef.current) clearedBeforeRestoreRef.current = true;
+
+    if (!persistenceEnabled || userId === null) return;
+    enqueueMutation(() => clearScheduleSwaps({ variables: { userId } }));
+  };
+
+  return {
+    plannedSwapsByTerm: swapsByTerm,
+    planSwap,
+    clearSwaps,
+    isPlanSettled: !loading || Boolean(error),
+  };
+};
+
+export default useScheduleSwaps;


### PR DESCRIPTION
## Summary

- restore saved Swap page plans from the backend instead of local storage
- overlay replacements on the unchanged Quest-imported schedule
- optimistically upsert, revert, and reset saved swaps
- serialize rapid mutations so an older choice cannot overwrite a newer one
- regenerate GraphQL types and add Apollo cache normalization for the composite swap key
- cover restore races, reset races, write ordering, failures, reverts, and demo mode

## Backend dependency

- UWFlow/uwflow#204
- https://github.com/UWFlow/uwflow/pull/204

## Verification

- bun run lint-nofix
- TypeScript no-emit check
- 39 Jest tests across 4 suites
- bun run build:vercel
- GraphQL code generation against an isolated migrated Hasura instance