### PR TITLE
fix(schedule): guide table-only Quest pastes

### DIFF
--- a/src/components/upload/ScheduleUploadModalContent.tsx
+++ b/src/components/upload/ScheduleUploadModalContent.tsx
@@ -71,12 +71,13 @@ const clipboardKeys = {
 // pastes on 2026-07-27 (see PR #287); that sample is a snapshot of one term's
 // Quest, not a contract.
 //
-// What keeps this acceptable is the blast radius: this function only picks an
-// error *string*. Nothing here affects what gets parsed or saved, so a pattern
-// that goes stale degrades to a vaguer message, never to a bad import. When one
-// does start misfiring, prefer deleting the specific case over hand-tuning the
-// pattern — a generic message beats a confidently wrong one. See the TODO on
-// getScheduleError below for the fix that removes the guesswork entirely.
+// These patterns only reject a paste when it is missing the term the backend
+// requires. Otherwise, they pick an error *string*. A pattern that goes stale
+// therefore degrades to the backend's existing response, never to a bad import.
+// When one does start misfiring, prefer deleting the specific case over
+// hand-tuning the pattern — a generic message beats a confidently wrong one.
+// See the TODO on getScheduleError below for the fix that removes the guesswork
+// entirely.
 
 // Quest prints this on My Class Schedule when the term has no enrolments. The
 // paste is well-formed, so it is not a copy/paste error — the term is empty.
@@ -92,6 +93,25 @@ const courseSelectionRegex = /my course selection/i;
 // that starts below Quest's term header has nothing for it to match, which is
 // the only way /parse/schedule can answer `bad_request` for a real paste.
 const termHeaderRegex = /(Spring|Fall|Winter)\s+\d{4}/;
+
+// Sentry failures show a common partial selection that starts at Quest's
+// desktop class table. Keep this horizontal so responsive/mobile layouts,
+// where each label is on its own line, are not given a desktop shortcut hint.
+const desktopClassTableHeaderRegex =
+  /^Class Nbr[ \t]+Section[ \t]+Component[ \t]+Days & Times[ \t]+Room[ \t]+Instructor[ \t]+Start\/End Date[ \t]*$/im;
+
+export const getSchedulePasteError = (
+  pastedSchedule: string,
+): string | null => {
+  if (
+    !termHeaderRegex.test(pastedSchedule) &&
+    desktopClassTableHeaderRegex.test(pastedSchedule)
+  ) {
+    return SCHEDULE_ERRORS.class_table_schedule;
+  }
+
+  return null;
+};
 
 /**
  * Picks the error message for a failed `/parse/schedule` response. The backend
@@ -116,8 +136,14 @@ export const getScheduleError = (error: string, pastedSchedule: string) => {
     return SCHEDULE_ERRORS.empty_schedule;
   }
 
-  if (error === 'bad_request' && !termHeaderRegex.test(pastedSchedule)) {
-    return SCHEDULE_ERRORS.no_term_schedule;
+  if (error === 'bad_request') {
+    const pasteError = getSchedulePasteError(pastedSchedule);
+    if (pasteError) {
+      return pasteError;
+    }
+    if (!termHeaderRegex.test(pastedSchedule)) {
+      return SCHEDULE_ERRORS.no_term_schedule;
+    }
   }
 
   return SCHEDULE_ERRORS[error] || SCHEDULE_ERRORS.default_schedule;
@@ -186,6 +212,13 @@ const ScheduleUploadModalContent = ({
     setScheduleText(pastedSchedule);
 
     if (pastedSchedule === '') {
+      return;
+    }
+
+    const pasteError = getSchedulePasteError(pastedSchedule);
+    if (pasteError) {
+      setUploadState(UPLOAD_FAILED);
+      setUploadError(pasteError);
       return;
     }
 
@@ -353,7 +386,8 @@ const ScheduleUploadModalContent = ({
           <InstructionWrapper>
             <NumberCircle>2</NumberCircle>
             <InstructionText>
-              Pick your term then select all (Ctrl+A) and copy (Ctrl+C)
+              Pick your term and switch to List View, then press Ctrl + A
+              (Windows) or CMD + A (Mac) and copy
             </InstructionText>
           </InstructionWrapper>
           <ScheduleStepPicture

--- a/src/components/upload/__tests__/ScheduleUploadModalContent.test.ts
+++ b/src/components/upload/__tests__/ScheduleUploadModalContent.test.ts
@@ -4,7 +4,18 @@ import { ScheduleParseResponse } from 'types/Api';
 import {
   getScheduleError,
   getScheduleImportOutcome,
+  getSchedulePasteError,
 } from '../ScheduleUploadModalContent';
+
+const desktopClassTablePaste = `BIOL 110 - Biodiversity, Biomes & Evol
+Class Nbr	Section	Component	Days & Times	Room	Instructor	Start/End Date
+7046
+001
+LEC
+MW 1:30PM - 2:20PM
+STC 1012
+Marcel Pinheiro
+09/09/2026 - 12/08/2026`;
 
 /**
  * The backend reports only a coarse enum for a failed schedule paste:
@@ -87,8 +98,7 @@ Course Selection Session
   });
 
   describe('bad_request', () => {
-    it('explains the missing term header when the paste has no term', () => {
-      // Selection started below Quest's term header: the class table alone.
+    it('explains the missing term header for an unrecognized paste', () => {
       const paste = `AFM 462 - Topics: Taxation
 Class Nbr	Section	Component	Days & Times
 3422
@@ -99,6 +109,12 @@ M 1:00PM - 2:50PM
 
       expect(getScheduleError('bad_request', paste)).toBe(
         SCHEDULE_ERRORS.no_term_schedule,
+      );
+    });
+
+    it('recognizes the desktop Quest class table copied without its term', () => {
+      expect(getScheduleError('bad_request', desktopClassTablePaste)).toBe(
+        SCHEDULE_ERRORS.class_table_schedule,
       );
     });
 
@@ -119,6 +135,36 @@ M 1:00PM - 2:50PM
     expect(getScheduleError('internal_error', emptyTermPaste)).toBe(
       SCHEDULE_ERRORS.default_schedule,
     );
+  });
+});
+
+describe('getSchedulePasteError', () => {
+  it('detects the table-only desktop paste before it reaches the backend', () => {
+    expect(getSchedulePasteError(desktopClassTablePaste)).toBe(
+      SCHEDULE_ERRORS.class_table_schedule,
+    );
+  });
+
+  it('allows the same desktop table when its term header is included', () => {
+    expect(
+      getSchedulePasteError(
+        `Fall 2026 | Undergraduate\n${desktopClassTablePaste}`,
+      ),
+    ).toBeNull();
+  });
+
+  it('does not give a desktop shortcut hint for responsive table labels', () => {
+    const responsivePaste = `BIOL 110 - Biodiversity, Biomes & Evol
+Class Nbr
+Section
+Component
+Days & Times
+Room
+Instructor
+Start/End Date
+7046`;
+
+    expect(getSchedulePasteError(responsivePaste)).toBeNull();
   });
 });
 

--- a/src/constants/Messages.tsx
+++ b/src/constants/Messages.tsx
@@ -38,12 +38,14 @@ const joinClassNumbers = (classes: number[]) =>
   classes.join(', ').replace(/, ((?:.(?!, ))+)$/, ' and $1');
 
 export const SCHEDULE_ERRORS: MessageObject = {
+  class_table_schedule:
+    'It looks like only your classes were copied. In Quest List View, press Ctrl + A (Windows) or CMD + A (Mac) to select the whole page, then copy and paste again.',
   course_selection_schedule:
     'That looks like your Course Selection page – in Quest, go to Enroll → My Class Schedule and paste that instead.',
   not_registered_schedule:
     'That schedule is empty – Quest says you’re not registered for classes in that term. Try a term you’re enrolled in.',
   no_term_schedule:
-    'We couldn’t find a term on that page – in Quest, go to Enroll → My Class Schedule, switch to List View, then select all (Ctrl+A) so the term header (e.g. “Fall 2026 | Undergraduate”) is included.',
+    'We couldn’t find a term on that page. In Quest, switch to List View, then press Ctrl + A (Windows) or CMD + A (Mac) before copying so the term header (e.g. “Fall 2026 | Undergraduate”) is included.',
   empty_schedule:
     'Looks like that schedule is empty. Check for copy/paste errors, and try again.',
   old_schedule:


### PR DESCRIPTION
## Summary

- detect the desktop Quest class-table paste seen in Sentry before it reaches the parser when the required term header is missing
- show explicit Ctrl + A (Windows) or CMD + A (Mac) retry guidance and update the upload instructions with both shortcuts
- preserve the existing generic fallback for other missing-term pastes and avoid applying the desktop hint to responsive table labels

## Evidence

- Sentry issue: https://flow-fa.sentry.io/issues/7565100386/events/e896737c65b246e2823cfa1bd75cc0d1/
- in the 883-paste Sentry sample, 268 pastes matched this horizontal desktop table header while omitting the term header
- the backend parser already requires a Spring, Fall, or Winter term header, so these table-only selections cannot parse successfully

## Testing

- bun run test --runInBand --watchAll=false src/components/upload/__tests__/ScheduleUploadModalContent.test.ts
- bun run lint-nofix
- bun run build:vercel