### PR TITLE
fix(schedule): broaden incomplete Quest paste detection

### DIFF
--- a/src/components/upload/ScheduleUploadModalContent.tsx
+++ b/src/components/upload/ScheduleUploadModalContent.tsx
@@ -94,18 +94,18 @@ const courseSelectionRegex = /my course selection/i;
 // the only way /parse/schedule can answer `bad_request` for a real paste.
 const termHeaderRegex = /(Spring|Fall|Winter)\s+\d{4}/;
 
-// Sentry failures show a common partial selection that starts at Quest's
-// desktop class table. Keep this horizontal so responsive/mobile layouts,
-// where each label is on its own line, are not given a desktop shortcut hint.
-const desktopClassTableHeaderRegex =
-  /^Class Nbr[ \t]+Section[ \t]+Component[ \t]+Days & Times[ \t]+Room[ \t]+Instructor[ \t]+Start\/End Date[ \t]*$/im;
+// Sentry failures show partial selections across multiple Quest layouts. Any
+// one of these schedule-table labels identifies the source; the missing term
+// that the backend requires is what makes it safe to stop before the request.
+const scheduleTableMarkerRegex =
+  /\b(?:Class Nbr|Section|Component|Days & Times|Room|Instructor|Start\/End Date)\b/i;
 
 export const getSchedulePasteError = (
   pastedSchedule: string,
 ): string | null => {
   if (
     !termHeaderRegex.test(pastedSchedule) &&
-    desktopClassTableHeaderRegex.test(pastedSchedule)
+    scheduleTableMarkerRegex.test(pastedSchedule)
   ) {
     return SCHEDULE_ERRORS.class_table_schedule;
   }

--- a/src/components/upload/__tests__/ScheduleUploadModalContent.test.ts
+++ b/src/components/upload/__tests__/ScheduleUploadModalContent.test.ts
@@ -100,7 +100,6 @@ Course Selection Session
   describe('bad_request', () => {
     it('explains the missing term header for an unrecognized paste', () => {
       const paste = `AFM 462 - Topics: Taxation
-Class Nbr	Section	Component	Days & Times
 3422
 001
 LEC
@@ -112,7 +111,7 @@ M 1:00PM - 2:50PM
       );
     });
 
-    it('recognizes the desktop Quest class table copied without its term', () => {
+    it('recognizes a Quest class table copied without its term', () => {
       expect(getScheduleError('bad_request', desktopClassTablePaste)).toBe(
         SCHEDULE_ERRORS.class_table_schedule,
       );
@@ -139,7 +138,7 @@ M 1:00PM - 2:50PM
 });
 
 describe('getSchedulePasteError', () => {
-  it('detects the table-only desktop paste before it reaches the backend', () => {
+  it('detects the table-only paste before it reaches the backend', () => {
     expect(getSchedulePasteError(desktopClassTablePaste)).toBe(
       SCHEDULE_ERRORS.class_table_schedule,
     );
@@ -153,18 +152,24 @@ describe('getSchedulePasteError', () => {
     ).toBeNull();
   });
 
-  it('does not give a desktop shortcut hint for responsive table labels', () => {
-    const responsivePaste = `BIOL 110 - Biodiversity, Biomes & Evol
-Class Nbr
-Section
-Component
-Days & Times
-Room
-Instructor
-Start/End Date
-7046`;
+  it('detects any schedule table marker when the term header is absent', () => {
+    const markers = [
+      'Class Nbr',
+      'Section',
+      'Component',
+      'Days & Times',
+      'Room',
+      'Instructor',
+      'Start/End Date',
+    ];
 
-    expect(getSchedulePasteError(responsivePaste)).toBeNull();
+    markers.forEach((marker) => {
+      expect(
+        getSchedulePasteError(
+          `BIOL 110 - Biodiversity, Biomes & Evol\n${marker}`,
+        ),
+      ).toBe(SCHEDULE_ERRORS.class_table_schedule);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- follow up on the review comment from #298 by matching any Quest schedule-table marker when the parser-valid term is absent
- retain the valid-term guard and use word boundaries around the seven known labels
- cover every marker plus the valid-term escape case in the focused upload tests

## Evidence

- review comment: https://github.com/UWFlow/uwflow_frontend/pull/298#discussion_r3700879389
- the broader detector matches 604 of the 750 missing-term pastes in the 883-paste Sentry sample

## Testing

- bun run test --runInBand --watchAll=false src/components/upload/__tests__/ScheduleUploadModalContent.test.ts
- bun run lint-nofix
- bun run build:vercel