### PR TITLE
feat(banner): announce scheduled maintenance window

### DIFF
--- a/src/components/banner/AnnouncementBanner.tsx
+++ b/src/components/banner/AnnouncementBanner.tsx
@@ -1,12 +1,10 @@
 import React, { useState } from 'react';
 import FadeIn from 'react-fade-in';
-import { ArrowRight, Repeat, X } from 'react-feather';
-import { Link } from 'react-router-dom';
-import { SWAP_PAGE_ROUTE } from 'Routes';
+import { Tool, X } from 'react-feather';
 
 // Bump the banner ID when announcing something new so the banner reappears
 // for users who dismissed a previous announcement.
-const BANNER_ID = 'class-swapper';
+const BANNER_ID = 'maintenance-1am-est';
 
 const AnnouncementBanner = () => {
   const localStorageKey = `banner-dismissed-${BANNER_ID}`;
@@ -27,18 +25,11 @@ const AnnouncementBanner = () => {
   return (
     <FadeIn>
       <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 bg-accent px-6 py-3">
-        <Repeat aria-hidden="true" className="shrink-0 text-dark1" size={20} />
+        <Tool aria-hidden="true" className="shrink-0 text-dark1" size={20} />
         <div className="min-w-0 text-md text-dark1">
-          <strong>Introducing Class Swapper.</strong> No more Quest tab swapping
-          to figure out your ideal schedule.
+          <strong>Scheduled maintenance tonight, 1:00–2:00 AM EST.</strong> UW
+          Flow may be briefly unavailable during this window.
         </div>
-        <Link
-          className="flex shrink-0 items-center gap-2 rounded-lg bg-dark1 px-5 py-2.5 text-sm font-semibold text-white no-underline transition-colors hover:bg-primaryExtraDark hover:text-white"
-          to={SWAP_PAGE_ROUTE}
-        >
-          Start swapping
-          <ArrowRight aria-hidden="true" size={16} />
-        </Link>
         <button
           aria-label="Dismiss announcement"
           className="flex shrink-0 cursor-pointer items-center border-none bg-transparent p-1 text-dark1 opacity-60 transition-opacity hover:opacity-100"


### PR DESCRIPTION
going to migrate the EC2 instance to point to [uwflow](https://github.com/UWFlow/uwflow) instead of the old repo 

Repurposes the existing `AnnouncementBanner` for the upcoming maintenance window instead of the Class Swapper announcement.

- **Copy:** "Scheduled maintenance tonight, 1:00–2:00 AM EST. UW Flow may be briefly unavailable during this window."
- **Time:** 11pm–12am MST (UTC−7) → 1:00–2:00 AM EST (UTC−5).
- Bumped `BANNER_ID` to `maintenance-1am-est` so the banner reappears for anyone who dismissed the previous one.
- Swapped the icon (`Repeat` → `Tool`) and dropped the "Start swapping" CTA — maintenance has nowhere to link.

No date is hardcoded; the copy says "tonight". Merge/deploy the day of, and revert (or bump `BANNER_ID` again) afterward.

`bun run lint-nofix` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)