### PR TITLE
fix(swap): default the calendar to next term

### DIFF
--- a/src/pages/swapPage/SwapCalendar.tsx
+++ b/src/pages/swapPage/SwapCalendar.tsx
@@ -33,7 +33,12 @@ import {
 } from 'utils/Misc';
 
 import CourseSearchDropdown from './CourseSearchDropdown';
-import { getDisplayedTermPresence } from './displayedTerms';
+import {
+  getDisplayedTermPresence,
+  GRID_END_HOUR,
+  GRID_START_HOUR,
+  toDayIndexes,
+} from './displayedTerms';
 import EnrolledCourseDropdown from './EnrolledCourseDropdown';
 import ScheduleSwapPanel, {
   ProfessorSwapStats,
@@ -45,11 +50,7 @@ import useScheduleSwaps, {
   PlannedSwap,
 } from './useScheduleSwaps';
 
-const DAY_LETTERS = ['M', 'T', 'W', 'Th', 'F'];
 const DAY_LABELS = ['MON', 'TUE', 'WED', 'THU', 'FRI'];
-// Visible hour range of the grid: 8am to 10pm.
-const GRID_START_HOUR = 8;
-const GRID_END_HOUR = 22;
 
 // 24-hour "HH:MM" from seconds since midnight (`secsToTime` is 12-hour).
 const secsTo24hTime = (secs: number) =>
@@ -87,14 +88,6 @@ const getSectionVariant = (sectionName: string): CalendarEventVariant => {
 type SectionSelection = {
   courseCode: string;
   sectionType: string;
-};
-
-// Mon-Fri day columns for a meeting, keeping only meetings that start within
-// the visible hour range.
-const toDayIndexes = (days: string[], startSeconds: number): number[] => {
-  const startHour = startSeconds / 3600;
-  if (startHour < GRID_START_HOUR || startHour >= GRID_END_HOUR) return [];
-  return days.map((d) => DAY_LETTERS.indexOf(d)).filter((col) => col !== -1);
 };
 
 const timesOverlap = (s1: number, e1: number, s2: number, e2: number) =>
@@ -260,8 +253,11 @@ const SwapCalendar = ({
   const thisTermLabel = termCodeToDate(thisTermCode);
   const nextTermLabel = termCodeToDate(nextTermCode);
 
-  const { nextHasData } = getDisplayedTermPresence(schedule);
-  const defaultSelectedTerm = nextHasData
+  // Swapping starts from a click on the grid, so only default to next term when
+  // it actually draws blocks — a term of purely online/async sections would
+  // open on an empty calendar.
+  const { nextHasVisibleBlocks } = getDisplayedTermPresence(schedule);
+  const defaultSelectedTerm = nextHasVisibleBlocks
     ? DisplayedTerm.Next
     : DisplayedTerm.Current;
   const [selectedTerm, setSelectedTerm] =

--- a/src/pages/swapPage/SwapCalendar.tsx
+++ b/src/pages/swapPage/SwapCalendar.tsx
@@ -260,9 +260,10 @@ const SwapCalendar = ({
   const thisTermLabel = termCodeToDate(thisTermCode);
   const nextTermLabel = termCodeToDate(nextTermCode);
 
-  const { thisHasData, nextHasData } = getDisplayedTermPresence(schedule);
-  const defaultSelectedTerm =
-    !nextHasData || thisHasData ? DisplayedTerm.Current : DisplayedTerm.Next;
+  const { nextHasData } = getDisplayedTermPresence(schedule);
+  const defaultSelectedTerm = nextHasData
+    ? DisplayedTerm.Next
+    : DisplayedTerm.Current;
   const [selectedTerm, setSelectedTerm] =
     useState<DisplayedTerm>(defaultSelectedTerm);
   const selectedTermCode =

--- a/src/pages/swapPage/displayedTerms.test.ts
+++ b/src/pages/swapPage/displayedTerms.test.ts
@@ -44,10 +44,12 @@ describe('getDisplayedTermPresence', () => {
     expect(getDisplayedTermPresence([entryInTerm(thisTermCode)])).toEqual({
       thisHasData: true,
       nextHasData: false,
+      nextHasVisibleBlocks: false,
     });
     expect(getDisplayedTermPresence([entryInTerm(nextTermCode)])).toEqual({
       thisHasData: false,
       nextHasData: true,
+      nextHasVisibleBlocks: true,
     });
   });
 
@@ -56,6 +58,7 @@ describe('getDisplayedTermPresence', () => {
     expect(getDisplayedTermPresence([entryInTerm(thisTermCode - 10)])).toEqual({
       thisHasData: false,
       nextHasData: false,
+      nextHasVisibleBlocks: false,
     });
   });
 
@@ -63,6 +66,16 @@ describe('getDisplayedTermPresence', () => {
     expect(getDisplayedTermPresence([entryInTerm(thisTermCode, [])])).toEqual({
       thisHasData: true,
       nextHasData: false,
+      nextHasVisibleBlocks: false,
+    });
+  });
+
+  it('does not count a next term that draws no calendar blocks', () => {
+    // Online/async next term: the user has classes, but nothing to click.
+    expect(getDisplayedTermPresence([entryInTerm(nextTermCode, [])])).toEqual({
+      thisHasData: false,
+      nextHasData: true,
+      nextHasVisibleBlocks: false,
     });
   });
 
@@ -70,6 +83,7 @@ describe('getDisplayedTermPresence', () => {
     expect(getDisplayedTermPresence([])).toEqual({
       thisHasData: false,
       nextHasData: false,
+      nextHasVisibleBlocks: false,
     });
   });
 });

--- a/src/pages/swapPage/displayedTerms.ts
+++ b/src/pages/swapPage/displayedTerms.ts
@@ -2,11 +2,42 @@ import { UserScheduleFragment } from 'generated/graphql';
 
 import { getCurrentTermCode, getNextTermCode } from 'utils/Misc';
 
+const DAY_LETTERS = ['M', 'T', 'W', 'Th', 'F'];
+// Visible hour range of the grid: 8am to 10pm.
+export const GRID_START_HOUR = 8;
+export const GRID_END_HOUR = 22;
+
+// Mon-Fri day columns for a meeting, keeping only meetings that start within
+// the visible hour range.
+export const toDayIndexes = (
+  days: string[],
+  startSeconds: number,
+): number[] => {
+  const startHour = startSeconds / 3600;
+  if (startHour < GRID_START_HOUR || startHour >= GRID_END_HOUR) return [];
+  return days.map((d) => DAY_LETTERS.indexOf(d)).filter((col) => col !== -1);
+};
+
+const hasVisibleBlocks = (
+  entry: UserScheduleFragment['schedule'][number],
+): boolean =>
+  entry.section.meetings.some(
+    (m) =>
+      m.start_seconds != null &&
+      m.end_seconds != null &&
+      toDayIndexes(m.days as string[], m.start_seconds).length > 0,
+  );
+
 // Whether the schedule has classes in each of the two terms the swap calendar
 // shows (current + next). Drives the default term in SwapCalendar and the
 // "Import your schedule from Quest" empty-state prompt in SwapPage, so it sits
 // outside the component that both of them can reach. Sections carry their own
 // term_id, so this never has to infer a term from meeting dates.
+//
+// `*HasData` counts any enrolled section (an online/async course still means
+// "you have a schedule"); `nextHasVisibleBlocks` counts only sections that draw
+// a clickable block on the grid, since defaulting to a term with nothing to
+// click would strand the user on an empty calendar.
 export const getDisplayedTermPresence = (
   schedule: UserScheduleFragment['schedule'],
 ) => {
@@ -18,6 +49,10 @@ export const getDisplayedTermPresence = (
     ),
     nextHasData: schedule.some(
       (entry) => entry.section.term_id === nextTermCode,
+    ),
+    nextHasVisibleBlocks: schedule.some(
+      (entry) =>
+        entry.section.term_id === nextTermCode && hasVisibleBlocks(entry),
     ),
   };
 };


### PR DESCRIPTION
## Summary
- Default the swap calendar to next term whenever that term has classes, including when both this term and next term are populated.
- Still fall back to this term if next term has no classes.

## Test plan
- [ ] Open `/swap` with classes in both this term and next term — the calendar should start on next term.
- [ ] Switch to this term with the term tabs; selection still works.
- [ ] Open `/swap` with classes only in this term — the calendar should still start on this term.
- [ ] Open `/swap` with classes only in next term — the calendar should start on next term.


Made with [Cursor](https://cursor.com)